### PR TITLE
Fix iMessage sending in Claude Code by using 'participant' instead of 'buddy'

### DIFF
--- a/mac_messages_mcp/messages.py
+++ b/mac_messages_mcp/messages.py
@@ -496,7 +496,7 @@ def _send_message_to_recipient(recipient: str, message: str, contact_name: str =
         
         # Adjust the AppleScript command based on whether this is a group chat
         if not group_chat:
-            command = f'tell application "Messages" to send (read (POSIX file "{file_path}") as «class utf8») to buddy "{recipient}"'
+            command = f'tell application "Messages" to send (read (POSIX file "{file_path}") as «class utf8») to participant "{recipient}" of (1st service whose service type = iMessage)'
         else:
             command = f'tell application "Messages" to send (read (POSIX file "{file_path}") as «class utf8») to chat "{recipient}"'
         

--- a/mac_messages_mcp/messages.py
+++ b/mac_messages_mcp/messages.py
@@ -1097,8 +1097,8 @@ def _send_message_direct(
             set targetService to 1st service whose service type = iMessage
             
             try
-                -- Try to get the existing buddy if possible
-                set targetBuddy to buddy "{safe_recipient}" of targetService
+                -- Try to get the existing participant if possible
+                set targetBuddy to participant "{safe_recipient}" of targetService
                 
                 -- Send the message via iMessage
                 send "{safe_message}" to targetBuddy


### PR DESCRIPTION
## Summary

This PR fixes issue #7 where messages report as sent but don't actually deliver in Claude Code.

## Problem

The AppleScript `buddy` property appears to be deprecated or not working properly in newer macOS versions when used from Claude Code. The MCP server was using:
- `buddy "{recipient}"` for iMessage
- `participant "{recipient}"` for SMS

## Solution

Changed both message sending methods to use `participant` with proper service selection:
1. **File-based approach** (primary method) - line 499
2. **Direct approach** (fallback method) - line 1101

Both now use: `participant "{recipient}" of (1st service whose service type = iMessage)`

## Testing

- Tested on macOS with Claude Code
- Messages now successfully deliver via iMessage
- SMS fallback continues to work as expected

## Changes

- `messages.py`: Replace `buddy` with `participant` in both sending methods
- Maintain compatibility with existing SMS code which already uses `participant`

Fixes #7