### PR TITLE
fix: remove unsupported 'description' param from FastMCP init

### DIFF
--- a/mac_messages_mcp/server.py
+++ b/mac_messages_mcp/server.py
@@ -30,11 +30,8 @@ logging.basicConfig(
 
 logger = logging.getLogger("mac_messages_mcp")
 
-# Initialize the MCP server with proper description
-mcp = FastMCP(
-    "MessageBridge", 
-    description="A bridge for interacting with macOS Messages app"
-)
+# Initialize the MCP server
+mcp = FastMCP("MessageBridge")
 
 @mcp.tool()
 def tool_get_recent_messages(ctx: Context, hours: int = 24, contact: str = None) -> str:


### PR DESCRIPTION
The current version of FastMCP does not accept a 'description' parameter in its constructor, causing a TypeError when starting the server. This commit removes the parameter to fix compatibility with the latest FastMCP library.

Error fixed:
TypeError: FastMCP.__init__() got an unexpected keyword argument 'description'

🤖 Generated with [Claude Code](https://claude.ai/code)