### PR TITLE
docs: add Docker container integration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,54 @@ uvx mac-messages-mcp
 
 ⚠️ Only run one instance of the MCP server (either on Cursor or Claude Desktop), not both
 
+### Docker Container Integration
+
+If you need to connect to `mac-messages-mcp` from a Docker container, you'll need to use the `mcp-proxy` package to bridge the stdio-based server to HTTP.
+
+#### Setup Instructions
+
+1. **Install mcp-proxy on your macOS host:**
+```bash
+npm install -g mcp-proxy
+```
+
+2. **Start the proxy server:**
+```bash
+# Using the published version
+npx mcp-proxy uvx mac-messages-mcp --port 8000 --host 0.0.0.0
+
+# Or using local development (if you encounter issues)
+npx mcp-proxy uv run python -m mac_messages_mcp.server --port 8000 --host 0.0.0.0
+```
+
+3. **Connect from Docker:**
+Your Docker container can now connect to:
+- URL: `http://host.docker.internal:8000/mcp` (on macOS/Windows)
+- URL: `http://<host-ip>:8000/mcp` (on Linux)
+
+4. **Docker Compose example:**
+```yaml
+version: '3.8'
+services:
+  your-app:
+    image: your-image
+    environment:
+      MCP_MESSAGES_URL: "http://host.docker.internal:8000/mcp"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"  # For Linux hosts
+```
+
+5. **Running multiple MCP servers:**
+```bash
+# Terminal 1 - Messages MCP on port 8001
+npx mcp-proxy uvx mac-messages-mcp --port 8001 --host 0.0.0.0
+
+# Terminal 2 - Another MCP server on port 8002
+npx mcp-proxy uvx another-mcp-server --port 8002 --host 0.0.0.0
+```
+
+**Note:** Binding to `0.0.0.0` exposes the service to all network interfaces. In production, consider using more restrictive host bindings and adding authentication.
+
 
 ### Option 1: Install from PyPI
 


### PR DESCRIPTION
## Summary
- Added comprehensive Docker integration documentation to README.md
- Explains how to use mcp-proxy to bridge stdio MCP servers to HTTP for Docker access
- Includes practical examples and security considerations

## What's Changed
- Added new "Docker Container Integration" section to README.md with:
  - Step-by-step setup instructions for mcp-proxy
  - Connection URLs for Docker containers
  - Docker Compose configuration example
  - Instructions for running multiple MCP servers
  - Security notes about network exposure

## Why This Change?
Users running MCP clients in Docker containers cannot directly connect to stdio-based MCP servers running on the host. This documentation provides a clean solution using mcp-proxy to bridge the communication gap, enabling seamless Docker integration.

## Test Plan
- [x] Tested mcp-proxy installation
- [x] Verified proxy starts successfully with mac-messages-mcp
- [x] Confirmed Docker containers can connect via host.docker.internal
- [x] Validated multiple MCP servers can run on different ports

🤖 Generated with [Claude Code](https://claude.ai/code)