### PR TITLE
feat: add description to FastMCP server

### DIFF
--- a/mac_messages_mcp/server.py
+++ b/mac_messages_mcp/server.py
@@ -31,7 +31,7 @@ logging.basicConfig(
 logger = logging.getLogger("mac_messages_mcp")
 
 # Initialize the MCP server
-mcp = FastMCP("MessageBridge")
+mcp = FastMCP("MessageBridge", description="A bridge for interacting with macOS Messages app")
 
 @mcp.tool()
 def tool_get_recent_messages(ctx: Context, hours: int = 24, contact: str = None) -> str:


### PR DESCRIPTION
"/Users/sq/.cache/uv/archive-v0/boOkkWlDWXxo7ZyZ9I3a_/bin/mac-messages-mcp", line 6, in <module>
    from mac_messages_mcp.server import run_server
  File "/Users/sq/.cache/uv/archive-v0/boOkkWlDWXxo7ZyZ9I3a_/lib/python3.12/site-packages/mac_messages_mcp/server.py", line 34, in <module>
    mcp = FastMCP(
          ^^^^^^^^
TypeError: FastMCP.__init__() got an unexpected keyword argument 'description'