### PR TITLE
Revert "feat: add description to FastMCP server"

### DIFF
--- a/mac_messages_mcp/server.py
+++ b/mac_messages_mcp/server.py
@@ -31,7 +31,7 @@ logging.basicConfig(
 logger = logging.getLogger("mac_messages_mcp")
 
 # Initialize the MCP server
-mcp = FastMCP("MessageBridge", description="A bridge for interacting with macOS Messages app")
+mcp = FastMCP("MessageBridge")
 
 @mcp.tool()
 def tool_get_recent_messages(ctx: Context, hours: int = 24, contact: str = None) -> str:


### PR DESCRIPTION
Reverts carterlasalle/mac_messages_mcp#26

It was my mistake; the new version `mcp[cli]>1.7`no longer needs a description.
description arguments is optional 