### PR TITLE
Fix FastMCP API compatibility issue

### DIFF
--- a/mac_messages_mcp/server.py
+++ b/mac_messages_mcp/server.py
@@ -31,7 +31,7 @@ logging.basicConfig(
 logger = logging.getLogger("mac_messages_mcp")
 
 # Initialize the MCP server
-mcp = FastMCP("MessageBridge", description="A bridge for interacting with macOS Messages app")
+mcp = FastMCP("MessageBridge", instructions="A bridge for interacting with macOS Messages app")
 
 @mcp.tool()
 def tool_get_recent_messages(ctx: Context, hours: int = 24, contact: str = None) -> str:


### PR DESCRIPTION
## Summary
This PR fixes a compatibility issue with the current FastMCP API that prevented the server from starting.

## Problem
The server was failing to start with the following error:
```
TypeError: FastMCP.__init__() got an unexpected keyword argument 'description'
```

## Solution
Changed the `description` parameter to `instructions` in the FastMCP initialization on line 34 of `mac_messages_mcp/server.py`. The FastMCP API was updated to use `instructions` instead of `description` in recent versions.

## Changes
- Updated `FastMCP("MessageBridge", description=...)` to `FastMCP("MessageBridge", instructions=...)`

## Testing
- Verified the server starts successfully after the change
- No functional changes to the server behavior

## References
This change aligns with the current FastMCP API signature which accepts `instructions` as the second positional argument for describing the server's purpose.