### PR TITLE
Fix NameError in _send_message_to_recipient: define safe_recipient

### DIFF
--- a/mac_messages_mcp/messages.py
+++ b/mac_messages_mcp/messages.py
@@ -663,6 +663,14 @@ def _send_message_to_recipient(recipient: str, message: str, contact_name: str =
         finally:
             tmp.close()
 
+        # Sanitize the recipient before embedding it in AppleScript.
+        # Without this, `safe_recipient` is undefined inside this function and
+        # both branches below raise NameError on every call. The exception is
+        # swallowed by the outer `except Exception`, which silently routes
+        # every send through `_send_message_direct`, making this entire
+        # file-based code path effectively dead.
+        safe_recipient = recipient.replace('\\', '\\\\').replace('"', '\\"')
+
         # Adjust the AppleScript command based on whether this is a group chat
         if not group_chat:
             command = f'tell application "Messages" to send (read (POSIX file "{file_path}") as «class utf8») to participant "{safe_recipient}" of (1st service whose service type = iMessage)'


### PR DESCRIPTION
`_send_message_to_recipient` references `safe_recipient` at lines 668 and 670 but never defines it inside the function. The variable is only defined locally inside `_send_message_sms` and `_send_message_direct`, not in the shared lexical scope.

Effect: every call to `_send_message_to_recipient` raises NameError on the f-string evaluation. The exception is swallowed by the outer `except Exception` block, which silently falls through to `_send_message_direct`. The file-based send path this function implements never actually runs in production — every send goes through the direct path instead.

This is hard to spot because the fallback masks the failure. The symptom is that the file-based approach (which exists specifically to handle messages with characters that AppleScript would otherwise choke on) never gets exercised, and any improvement made to it is silently dead code.

Fix: define `safe_recipient` locally in `_send_message_to_recipient` using the same escaping pattern (`\\` and `"`) that `_send_message_direct` uses on line 1259, so the file-based path actually runs and handles the cases it was designed for.

8 lines added, 0 removed. No behavior change for callers when `safe_recipient` would have been an unescaped recipient anyway; for recipients containing backslashes or double quotes, the file-based path now succeeds instead of falling through to the direct path.