### PR TITLE
Fix group chat send: use `chat id` instead of `chat`

### DIFF
--- a/mac_messages_mcp/messages.py
+++ b/mac_messages_mcp/messages.py
@@ -667,7 +667,11 @@ def _send_message_to_recipient(recipient: str, message: str, contact_name: str =
         if not group_chat:
             command = f'tell application "Messages" to send (read (POSIX file "{file_path}") as «class utf8») to participant "{safe_recipient}" of (1st service whose service type = iMessage)'
         else:
-            command = f'tell application "Messages" to send (read (POSIX file "{file_path}") as «class utf8») to chat "{safe_recipient}"'
+            # Group chats are addressed by their full chat id (e.g. "iMessage;+;chat123…").
+            # The Messages dictionary requires `chat id "…"`, NOT `chat "…"`:
+            # the latter looks up by the chat's display name and fails for guid-style
+            # identifiers (raises -1728 "Can't get chat …").
+            command = f'tell application "Messages" to send (read (POSIX file "{file_path}") as «class utf8») to chat id "{safe_recipient}"'
         
         # Run the AppleScript
         result = run_applescript(command)
@@ -1255,8 +1259,10 @@ def _send_message_direct(
         script = f'''
         tell application "Messages"
             try
-                -- Try to get the existing chat
-                set targetChat to chat "{safe_recipient}"
+                -- Try to get the existing chat by its full id (e.g. "iMessage;+;chat123…").
+                -- `chat id "…"` looks up by guid; plain `chat "…"` looks up by display
+                -- name and fails on guid-style identifiers with -1728 "Can't get chat".
+                set targetChat to chat id "{safe_recipient}"
                 
                 -- Send the message
                 send "{safe_message}" to targetChat


### PR DESCRIPTION
## Problem

Sending to a group chat fails with AppleScript error `-1728 ("Can't get chat …")`.

The recipient passed to a group send is the chat's guid, e.g.:

```
iMessage;+;chat<digits>
```

The current code addresses it via `chat "…"`:

```applescript
tell application "Messages" to send … to chat "iMessage;+;chat<digits>"
```

But `chat "…"` in the Messages dictionary looks up by **display name**, not guid. For guid-style identifiers it always fails.

## Fix

Use `chat id "…"`, which is the documented accessor for guids:

```applescript
tell application "Messages" to send … to chat id "iMessage;+;chat<digits>"
```

Verified working locally — sent two messages into a real group chat with no error.

## Scope

Two call sites patched:

- `_send_message_to_recipient` (subprocess send path, group branch) — messages.py L670
- `_send_message_direct` (group_chat branch) — messages.py L1265

1:1 send (`participant "…" of (1st service …)`) is unchanged — it was already correct.

Comments added at each site explaining why `chat id` is required, so the next reader doesn't "fix" it back.

## Notes

Separate scope from #47 (AppleScript newline escaping). This PR only addresses the chat-id accessor.