### PR TITLE
fix(send): normalize phone recipients to E.164 (issue #51)

### DIFF
--- a/mac_messages_mcp/messages.py
+++ b/mac_messages_mcp/messages.py
@@ -617,6 +617,19 @@ def find_contact_by_name(name: str) -> List[Dict[str, Any]]:
 
     # Convert to sorted list
     results = sorted(seen_phones.values(), key=lambda x: x["score"], reverse=True)
+
+    # Return phone numbers in E.164 form (leading +) so the natural
+    # find_contact -> send_message round-trip lands in the reliable
+    # AppleScript routing path. AddressBook caches numbers as digit-only;
+    # we add + here without mutating the cache (handle lookups against
+    # chat.db still need the digit-only form).
+    for entry in results:
+        phone = entry.get("phone", "")
+        if phone and "@" not in phone and not phone.lstrip().startswith("+"):
+            digits = "".join(c for c in phone if c.isdigit())
+            if len(digits) >= 10:
+                entry["phone"] = "+" + digits
+
     return results
 
 def send_message(recipient: str, message: str, group_chat: bool = False) -> str:
@@ -662,8 +675,16 @@ def send_message(recipient: str, message: str, group_chat: bool = False) -> str:
     
     # Check if recipient is directly a phone number
     if all(c.isdigit() or c in '+- ()' for c in recipient):
-        # Clean the phone number
+        # Normalize phone numbers to E.164 form (leading +) before passing to
+        # AppleScript. iMessage's registered handles are E.164, and bare-digit
+        # forms route inconsistently — sometimes silently failing while the
+        # AppleScript "API" reports success. `normalize_phone_number` strips
+        # the +; we re-add it whenever the input was E.164 or has at least 10
+        # digits (long enough to be a country-code-bearing phone number).
+        has_plus = recipient.strip().startswith("+")
         clean_number = normalize_phone_number(recipient)
+        if clean_number and (has_plus or len(clean_number) >= 10):
+            clean_number = "+" + clean_number
         return _send_message_to_recipient(clean_number, message, group_chat=False)
 
     # Check if recipient is an email address

--- a/mac_messages_mcp/server.py
+++ b/mac_messages_mcp/server.py
@@ -45,14 +45,22 @@ def tool_get_recent_messages(
     ctx: Context,
     hours: Annotated[
         int,
-        Field(description="Number of hours to look back from now. Default is 24."),
+        Field(
+            description=(
+                "Number of hours to look back from now. Default 24, maximum 87600 "
+                "(10 years)."
+            ),
+            ge=0,
+            le=87600,
+        ),
     ] = 24,
     contact: Annotated[
         str | None,
         Field(
             description=(
-                "Optional contact filter: contact name, phone number, email address, "
-                'or "contact:N" from a previous contact match list.'
+                "Optional contact filter: a contact name (fuzzy-matched in AddressBook), "
+                "a phone number in E.164 with leading + (e.g. +14155551234), an email "
+                'address, or "contact:N" from a previous contact match list.'
             )
         ),
     ] = None,
@@ -86,8 +94,11 @@ def tool_send_message(
         str,
         Field(
             description=(
-                "Phone number, email address, contact name, contact:N selection, "
-                "or Messages chat ID when group_chat is true."
+                "Phone number in E.164 with leading + (e.g. +14155551234), email "
+                "address, contact name, contact:N selection from a prior match, or a "
+                "Messages chat ID from tool_get_chats when group_chat is true. Phone "
+                "numbers without a leading + may be misrouted (silently dropped while "
+                "the API reports success), so always pass +CCNNN…NNN."
             )
         ),
     ],
@@ -289,7 +300,10 @@ def tool_check_imessage_availability(
     recipient: Annotated[
         str,
         Field(
-            description="Phone number or email address to check for iMessage capability."
+            description=(
+                "Phone number in E.164 with leading + (e.g. +14155551234) or email "
+                "address to check for iMessage capability."
+            )
         ),
     ],
 ) -> str:
@@ -331,9 +345,11 @@ def tool_fuzzy_search_messages(
         int,
         Field(
             description=(
-                "Number of hours to search backward. Default is 720; use 0 for "
-                "all available messages."
-            )
+                "Number of hours to search backward. Default 720 (30 days); use 0 "
+                "for all available messages. Maximum 87600 (10 years)."
+            ),
+            ge=0,
+            le=87600,
         ),
     ] = 720,
     threshold: Annotated[
@@ -390,7 +406,10 @@ def tool_search_attachments(
     contact: Annotated[
         str | None,
         Field(
-            description="Optional contact name, phone number, or email address filter."
+            description=(
+                "Optional contact filter: contact name, phone number in E.164 with "
+                "leading + (e.g. +14155551234), or email address."
+            )
         ),
     ] = None,
     mime_type: Annotated[

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -487,5 +487,78 @@ class TestEscapeAppleScript(unittest.TestCase):
             'line1\\nline2\\"end\\\\',
         )
 
+
+class TestSendMessageE164Normalization(unittest.TestCase):
+    """`send_message` normalizes phone recipients to E.164 (leading +) before AppleScript."""
+
+    def _run_case(self, recipient, expected_clean):
+        with patch('mac_messages_mcp.messages._send_message_to_recipient') as mock_send:
+            mock_send.return_value = "Message sent successfully to test"
+            from mac_messages_mcp.messages import send_message
+            send_message(recipient=recipient, message="hello")
+            actual = mock_send.call_args.args[0]
+            self.assertEqual(
+                actual,
+                expected_clean,
+                f"recipient={recipient!r}: expected {expected_clean!r}, got {actual!r}",
+            )
+
+    def test_plus_e164_us(self):
+        self._run_case("+12064732279", "+12064732279")
+
+    def test_plus_e164_uk_with_spaces(self):
+        self._run_case("+44 7971 740664", "+447971740664")
+
+    def test_plus_e164_us_with_parens(self):
+        self._run_case("+1 (206) 473-2279", "+12064732279")
+
+    def test_bare_digits_us_country_code_gets_plus(self):
+        # 11 digits, country-code-bearing — must be prepended with + to route reliably.
+        self._run_case("12064732279", "+12064732279")
+
+    def test_bare_digits_uk_country_code_gets_plus(self):
+        # UK 12-digit, no leading + — bare-digit form is unreliable.
+        self._run_case("447967960994", "+447967960994")
+
+    def test_parens_ten_digits_gets_plus(self):
+        # 10 digits after stripping formatting — long enough to E.164-ify.
+        self._run_case("(206) 473-2279", "+2064732279")
+
+    def test_short_digit_string_left_unchanged(self):
+        # Below 10 digits is not a complete phone number; do not prepend +.
+        self._run_case("12345", "12345")
+
+
+class TestFindContactReturnsE164(unittest.TestCase):
+    """`find_contact_by_name` must return phone numbers in E.164 form so the find -> send round-trip stays in the reliable routing path."""
+
+    def _run(self, cached_contacts):
+        from mac_messages_mcp import messages
+        with patch.object(messages, "get_cached_contacts", return_value=cached_contacts), \
+             patch.object(messages, "_PHONE_TO_DETAILS_MAP", {}, create=True):
+            return messages.find_contact_by_name("Test")
+
+    def test_digit_only_phone_gets_plus(self):
+        results = self._run({"12064732279": "Test User"})
+        self.assertTrue(results, "expected at least one match")
+        self.assertEqual(results[0]["phone"], "+12064732279")
+
+    def test_already_plus_left_unchanged(self):
+        results = self._run({"+12064732279": "Test User"})
+        self.assertTrue(results)
+        self.assertEqual(results[0]["phone"], "+12064732279")
+
+    def test_email_left_unchanged(self):
+        results = self._run({"test@example.com": "Test User"})
+        self.assertTrue(results)
+        self.assertEqual(results[0]["phone"], "test@example.com")
+
+    def test_short_digits_left_unchanged(self):
+        # Sub-10-digit short codes are not E.164 candidates.
+        results = self._run({"12345": "Test User"})
+        self.assertTrue(results)
+        self.assertEqual(results[0]["phone"], "12345")
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

Closes #51.

Phone-number recipients sent through `send_message` are now reliably routed by ensuring they reach AppleScript in E.164 form (leading `+`).

## Why this matters

iMessage stores registered handles in E.164. AppleScript's send path exact-matches against those handles. Bare-digit forms sometimes match a cached chat and sometimes don't — and at least one mode reports *API success* while silently dropping the message. UK and other non-NANP forms suffer the same problem.

Reproduced live (per #51):

| Number          | Format used     | Result                                  |
|-----------------|-----------------|-----------------------------------------|
| US 11-digit     | `19565179045`   | API reported success, NOT delivered     |
| US 11-digit     | `+19565179045`  | Delivered                               |
| UK 12-digit     | `447967960994`  | Chat lookup failed                      |
| UK 12-digit     | `+447967960994` | Delivered                               |

The natural agent flow `find_contact -> send_message` was broken because `find_contact` returned numbers stripped of the `+`, feeding the unreliable code path back into the send tool.

## Changes

1. **`send_message` (`mac_messages_mcp/messages.py`)** — `normalize_phone_number` strips all non-digits including `+`, which is correct for SQL handle lookups against `chat.db` but wrong for the AppleScript send path. After normalization, the `+` is re-prepended whenever the input was E.164 or the resulting digit string is at least 10 chars long (long enough to be a country-code-bearing phone number). Sub-10-digit short codes are left alone.
2. **`find_contact_by_name` (`mac_messages_mcp/messages.py`)** — Phone numbers in the returned matches are upgraded to E.164 form before the function returns, so the round-trip back into `send_message` lands in the reliable path. The AddressBook cache itself is untouched (handle lookups against `chat.db` still need the digit-only form).
3. **Tool descriptions (`mac_messages_mcp/server.py`)** — `tool_send_message`, `tool_get_recent_messages`, `tool_check_imessage_availability`, `tool_search_attachments`, and `tool_fuzzy_search_messages` now spell out the E.164-with-leading-`+` format. Hour bounds are documented and validated where they were missing.
4. **Tests (`tests/test_messages.py`)** — `TestSendMessageE164Normalization` covers `+` preservation and digit-only normalization across NANP and UK forms, plus that sub-10-digit short codes are left unchanged. `TestFindContactReturnsE164` covers the find-side normalization with email and short-code edge cases.

Possibly related: #21 was closed without a normalisation fix and is in the same address-handling territory.

## Test plan

- [x] `pytest -x` — full suite green (114 tests, including 11 new ones)
- [ ] Smoke test: `find_contact "<name>"` then `send_message <returned phone>` — message delivers via iMessage
- [ ] Smoke test: `send_message "447967960994" "test"` — message delivers (was failing before)
- [ ] Smoke test: `send_message "+12064732279" "test"` — message delivers (regression check)