### PR TITLE
feat: add build_mcpb.py to build the Claude Desktop extension (.mcpb)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,4 +61,8 @@ venv.bak/
 *.swo
 
 # macOS
-.DS_Store 
+.DS_Store
+
+# MCPB build artifacts (vendored uv binary + packed extension)
+bin/
+*.mcpb 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,17 @@ Install the generated `.mcpb` file from Claude Desktop **Settings** > **Extensio
 
 Claude Desktop, or the terminal used to package/run the extension, still needs Full Disk Access to read Messages.
 
+**Bundling `uv` (self-contained `.mcpb`)**
+
+By default the packaged extension calls the system `uv`. To produce a `.mcpb` that also runs on machines without `uv` installed, use the build script, which vendors the `uv` binary into the bundle (`bin/uv`) and packs it:
+
+```bash
+python scripts/build_mcpb.py                  # build for the host architecture
+python scripts/build_mcpb.py --arch x86_64    # build for Intel macs
+```
+
+The `uv` binary is architecture specific, so build one `.mcpb` per architecture you support. On first launch the bundled `uv` still downloads Python and dependencies, so network access is required once. Pass `--no-bundle` to pack against the system `uv` instead; see `python scripts/build_mcpb.py --help` for all options.
+
 #### Option 2: Manual Config
 
 1. Go to **Claude** > **Settings** > **Developer** > **Edit Config** > **claude_desktop_config.json**

--- a/README.md
+++ b/README.md
@@ -101,16 +101,16 @@ Install the generated `.mcpb` file from Claude Desktop **Settings** > **Extensio
 
 Claude Desktop, or the terminal used to package/run the extension, still needs Full Disk Access to read Messages.
 
-**Bundling `uv` (self-contained `.mcpb`)**
+**Building the extension**
 
-By default the packaged extension calls the system `uv`. To produce a `.mcpb` that also runs on machines without `uv` installed, use the build script, which vendors the `uv` binary into the bundle (`bin/uv`) and packs it:
+Build the `.mcpb` with the build script:
 
 ```bash
 python scripts/build_mcpb.py                  # build for the host architecture
 python scripts/build_mcpb.py --arch x86_64    # build for Intel macs
 ```
 
-The `uv` binary is architecture specific, so build one `.mcpb` per architecture you support. On first launch the bundled `uv` still downloads Python and dependencies, so network access is required once. Pass `--no-bundle` to pack against the system `uv` instead; see `python scripts/build_mcpb.py --help` for all options.
+By default it vendors a `uv` binary into the bundle (`bin/uv`) so the extension also runs on machines without `uv` installed — that binary is architecture specific (build one `.mcpb` per arch) and downloads Python and dependencies on first launch (network required once). Pass `--no-bundle` to pack against the system `uv` instead; see `python scripts/build_mcpb.py --help` for all options.
 
 #### Option 2: Manual Config
 

--- a/scripts/build_mcpb.py
+++ b/scripts/build_mcpb.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""
+Build script for the Mac Messages MCP Claude Desktop extension (.mcpb).
+
+Vendors a `uv` binary into the bundle so the packaged extension runs on
+machines that don't have `uv` installed, then runs `mcpb pack`.
+
+Usage:
+    python scripts/build_mcpb.py [--arch arm64|x86_64] [--uv-version X.Y.Z] [--no-bundle]
+    python scripts/build_mcpb.py --help
+
+Options:
+    --arch         Target architecture (defaults to the host architecture).
+    --uv-version   uv release to vendor (default: pinned known-good version).
+    --no-bundle    Pack against the system `uv` without vendoring a binary.
+
+The vendored `uv` binary is architecture specific, so build one .mcpb per
+architecture you need to support. On first launch the bundled `uv` still
+downloads Python and dependencies, so network access is required once.
+"""
+
+import hashlib
+import json
+import platform
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import urllib.request
+from pathlib import Path
+
+# Pinned uv release for reproducible builds; override with --uv-version.
+DEFAULT_UV_VERSION = "0.11.19"
+UV_DOWNLOAD_URL = (
+    "https://github.com/astral-sh/uv/releases/download/{version}/{asset}.tar.gz"
+)
+
+# Map architecture aliases to uv's macOS release asset names.
+ARCH_ASSETS = {
+    "arm64": "uv-aarch64-apple-darwin",
+    "aarch64": "uv-aarch64-apple-darwin",
+    "x86_64": "uv-x86_64-apple-darwin",
+    "intel": "uv-x86_64-apple-darwin",
+}
+
+BIN_DIR = Path("bin")
+MANIFEST_PATH = Path("manifest.json")
+BUNDLED_COMMAND = "${__dirname}/bin/uv"
+
+
+def print_help():
+    """Print help information"""
+    print(__doc__)
+    sys.exit(0)
+
+
+def resolve_asset(arch):
+    """Map an architecture alias to uv's release asset name."""
+    key = (arch or platform.machine()).lower()
+    asset = ARCH_ASSETS.get(key)
+    if asset is None:
+        valid = ", ".join(sorted(set(ARCH_ASSETS)))
+        print(f"Error: unsupported arch '{key}'. Choose from: {valid}")
+        sys.exit(1)
+    return asset
+
+
+def _download(url):
+    """Download a URL and return the raw bytes."""
+    print(f"Downloading {url}")
+    with urllib.request.urlopen(url) as response:  # noqa: S310 (trusted release URL)
+        return response.read()
+
+
+def vendor_uv(asset, version):
+    """Download, checksum-verify, and extract the uv binary into bin/uv."""
+    url = UV_DOWNLOAD_URL.format(version=version, asset=asset)
+    archive = _download(url)
+
+    expected = _download(url + ".sha256").decode().split()[0]
+    actual = hashlib.sha256(archive).hexdigest()
+    if actual != expected:
+        print("Error: checksum mismatch for uv download")
+        print(f"  expected: {expected}")
+        print(f"  actual:   {actual}")
+        sys.exit(1)
+    print("Checksum verified")
+
+    BIN_DIR.mkdir(exist_ok=True)
+    uv_path = BIN_DIR / "uv"
+    with tempfile.TemporaryDirectory() as tmp:
+        tar_path = Path(tmp) / "uv.tar.gz"
+        tar_path.write_bytes(archive)
+        with tarfile.open(tar_path) as tar:
+            source = tar.extractfile(f"{asset}/uv")
+            uv_path.write_bytes(source.read())
+    uv_path.chmod(0o755)
+    print(f"Vendored uv {version} ({asset}) -> {uv_path}")
+
+
+def mcpb_cli():
+    """Return the command used to invoke the mcpb CLI."""
+    if shutil.which("mcpb"):
+        return ["mcpb"]
+    return ["npx", "--yes", "@anthropic-ai/mcpb"]
+
+
+def pack(bundle):
+    """Run `mcpb pack`, temporarily pointing the manifest at the bundled uv.
+
+    The tracked manifest.json is always restored afterwards so the default
+    system-uv flow stays unchanged.
+    """
+    original = MANIFEST_PATH.read_text()
+    try:
+        if bundle:
+            manifest = json.loads(original)
+            manifest["server"]["mcp_config"]["command"] = BUNDLED_COMMAND
+            MANIFEST_PATH.write_text(json.dumps(manifest, indent=2) + "\n")
+            print(f"manifest command -> {BUNDLED_COMMAND}")
+        subprocess.run(mcpb_cli() + ["pack"], check=True)
+    finally:
+        MANIFEST_PATH.write_text(original)
+        if bundle:
+            print("Restored manifest.json")
+
+
+def main():
+    args = sys.argv[1:]
+    if any(a in ("-h", "--help", "help") for a in args):
+        print_help()
+
+    arch = None
+    uv_version = DEFAULT_UV_VERSION
+    bundle = True
+
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg == "--arch":
+            i += 1
+            if i >= len(args):
+                print("Error: --arch requires a value")
+                sys.exit(1)
+            arch = args[i]
+        elif arg == "--uv-version":
+            i += 1
+            if i >= len(args):
+                print("Error: --uv-version requires a value")
+                sys.exit(1)
+            uv_version = args[i]
+        elif arg == "--no-bundle":
+            bundle = False
+        else:
+            print(f"Error: unknown argument '{arg}'")
+            print(
+                "Usage: python scripts/build_mcpb.py [--arch arm64|x86_64] "
+                "[--uv-version X.Y.Z] [--no-bundle]"
+            )
+            sys.exit(1)
+        i += 1
+
+    if sys.platform != "darwin":
+        print("Warning: mac-messages-mcp targets macOS; building on a non-macOS host.")
+
+    if bundle:
+        asset = resolve_asset(arch)
+        vendor_uv(asset, uv_version)
+    else:
+        print("Packing against system uv (no vendored binary).")
+
+    pack(bundle)
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

The repo already ships an MCPB `manifest.json`, but there were no instructions or tooling for actually building the `.mcpb` from it. This adds `scripts/build_mcpb.py` — a one-command build for the Claude Desktop extension — and documents it in the README. By default the build produces a **self-contained `.mcpb`** that bundles `uv`, so it also runs on machines without `uv` installed.

This allows a simple one-click install of the MCP on Claude Desktop, and makes the MCP server easily distributable to less technical org-members. 

https://github.com/user-attachments/assets/2b11cc8a-5963-435a-9faa-f323ef6285a9

## Why

Building the `.mcpb` was an undocumented, manual sequence. The shipped `manifest.json` also invokes the system `uv`, so a packaged extension fails on a machine without `uv` on `PATH` (and macOS GUI apps get a minimal `PATH`, so even a Homebrew `uv` may not resolve). The script makes the build one command and, by default, vendors uv's single static binary into the bundle (pointing the manifest command at `${__dirname}/bin/uv`) so the extension is portable.

## How it works

`python scripts/build_mcpb.py` runs `mcpb pack`, and by default also:
1. Downloads the `uv` release for the target arch (default: host) and **verifies its SHA-256**.
2. Extracts it to `bin/uv`.
3. Temporarily sets the manifest `command` to `${__dirname}/bin/uv`, then **restores `manifest.json`** afterwards so the default system-`uv` flow is unchanged.

Flags: `--arch arm64|x86_64`, `--uv-version X.Y.Z`, `--no-bundle` (pack against system `uv`). Stdlib only; follows the existing `scripts/bump_version.py` style. Falls back to `npx @anthropic-ai/mcpb` when `mcpb` isn't on `PATH`.

## Notes

- The vendored binary is arch-specific — build one `.mcpb` per arch.
- First launch still needs network once (bundled `uv` fetches Python + deps).
- `bin/` and `*.mcpb` are gitignored so the binary/artifact aren't committed.