### PR TITLE
Harden local data access, CI, and releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          version: "0.9.25"
+          enable-cache: true
+      - name: Install dependencies
+        run: uv sync --frozen --extra dev --python ${{ matrix.python-version }}
+      - name: Test
+        run: uv run --frozen --extra dev --python ${{ matrix.python-version }} pytest
+
+  quality-and-package:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          version: "0.9.25"
+          enable-cache: true
+      - name: Install dependencies
+        run: uv sync --frozen --extra dev --python 3.13
+      - name: Formatting
+        run: |
+          uv run --frozen --extra dev black --check .
+          uv run --frozen --extra dev isort --check-only .
+      - name: Build distributions
+        run: uv build
+      - name: Verify wheel installation
+        run: |
+          uv venv --python 3.13 /tmp/mac-messages-wheel
+          uv pip install --python /tmp/mac-messages-wheel/bin/python dist/*.whl
+          /tmp/mac-messages-wheel/bin/python -c "import mac_messages_mcp; assert mac_messages_mcp.__version__ != '0.0.0+local'"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,44 +5,31 @@ on:
     tags:
       - 'v*'  # Only run when pushing tags that start with 'v'
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
         fetch-depth: 0  # Fetch all history for tag discovery
     
-    - name: Set up Python
-      uses: actions/setup-python@v6
+    - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
       with:
-        python-version: '3.10'
-    
-    - name: Extract version from tag
-      id: get_version
+        version: "0.9.25"
+
+    - name: Verify tag matches package metadata
       run: |
-        # Strip the 'v' prefix from the tag name
         VERSION=${GITHUB_REF#refs/tags/v}
-        echo "VERSION=$VERSION" >> $GITHUB_ENV
-        echo "version=$VERSION" >> $GITHUB_OUTPUT
-    
-    - name: Update version in files
-      run: |
-        # Update version in __init__.py
-        sed -i "s/__version__ = \".*\"/__version__ = \"$VERSION\"/" mac_messages_mcp/__init__.py
-        
-        # Update version in pyproject.toml
-        sed -i "s/version = \".*\"/version = \"$VERSION\"/" pyproject.toml
-        
-        # Show the changes
-        git diff
-    
-    - name: Install uv
-      run: python -m pip install --upgrade uv
-    
+        PROJECT_VERSION=$(uv run --no-project python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')
+        MANIFEST_VERSION=$(uv run --no-project python -c 'import json; print(json.load(open("manifest.json"))["version"])')
+        test "$VERSION" = "$PROJECT_VERSION"
+        test "$VERSION" = "$MANIFEST_VERSION"
+
     - name: Build and publish
-      env:
-        UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
       run: |
         uv build
-        uv publish
+        uv publish --trusted-publishing always

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,20 @@
+# Contributing
+
+## Setup
+
+```bash
+uv sync --frozen --extra dev
+```
+
+## Checks
+
+```bash
+uv run pytest
+uv run black --check .
+uv run isort --check-only .
+uv build
+```
+
+Tests must not access a contributor's real Messages or Contacts data. Use temporary SQLite fixtures and mock AppleScript execution. Never commit database copies, phone numbers, contact exports, messages, or attachments.
+
+Keep pull requests focused and document user impact, privacy implications, macOS/Python versions tested, and the commands used for validation.

--- a/README.md
+++ b/README.md
@@ -1,20 +1,14 @@
 # Mac Messages MCP
 
-A Python bridge for interacting with the macOS Messages app using MCP (Multiple Context Protocol). 
+A local-first Model Context Protocol server for reading, searching, and sending through the macOS Messages app.
 
-[![PyPI Downloads](https://static.pepy.tech/badge/mac-messages-mcp)](https://pepy.tech/projects/mac-messages-mcp)
-
-[![Trust Score](https://archestra.ai/mcp-catalog/api/badge/quality/carterlasalle/mac_messages_mcp)](https://archestra.ai/mcp-catalog/carterlasalle__mac_messages_mcp)
-[![mac_messages_mcp MCP score](https://glama.ai/mcp/servers/carterlasalle/mac_messages_mcp/badges/score.svg)](https://glama.ai/mcp/servers/carterlasalle/mac_messages_mcp)
+[![PyPI](https://img.shields.io/pypi/v/mac-messages-mcp)](https://pypi.org/project/mac-messages-mcp/)
+[![Python](https://img.shields.io/pypi/pyversions/mac-messages-mcp)](https://pypi.org/project/mac-messages-mcp/)
+[![CI](https://github.com/carterlasalle/mac_messages_mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/carterlasalle/mac_messages_mcp/actions/workflows/ci.yml)
 
 ![a-diagram-of-a-mac-computer-with-the-tex_FvvnmbaBTFeKy6F2GMlLqA_IfCBMgJARcia1WTH7FaqwA](https://github.com/user-attachments/assets/dbbdaa14-fadd-434d-a265-9e0c0071c11d)
 
-[![Verified on MseeP](https://mseep.ai/badge.svg)](https://mseep.ai/app/fdc62324-6ac9-44e2-8926-722d1157759a)
-
-
-<a href="https://glama.ai/mcp/servers/gxvaoc9znc">
-  <img width="380" height="200" src="https://glama.ai/mcp/servers/gxvaoc9znc/badge" />
-</a>
+Messages and contacts stay on the Mac where this server runs. Database connections are opened read-only; sending is a separate, explicit tool that uses Messages.app automation.
 
 ## Quick Install
 
@@ -59,6 +53,16 @@ For direct sends, E.164 phone numbers with a leading `+` are the most reliable f
 - macOS (tested on macOS 11+)
 - Python 3.10+
 - **uv package manager**
+
+## Security and privacy model
+
+- Message and Contacts databases are opened with SQLite `mode=ro` and `query_only` enabled.
+- The server does not upload a message archive or maintain its own copy of the databases.
+- MCP clients receive only tool results requested in the current session. Attachment retrieval is deliberate and size limited.
+- Sending requires an explicit `tool_send_message` call and uses escaped AppleScript values with a bounded execution timeout.
+- Full Disk Access is powerful. Grant it only to the specific trusted client that launches this server.
+
+See [SECURITY.md](SECURITY.md) for private vulnerability reporting.
 
 ### Installing uv
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+Security fixes are applied to the latest release and the `main` branch.
+
+Report vulnerabilities privately through GitHub's **Security → Report a vulnerability** flow for this repository. Include affected versions, reproduction steps, impact, and any suggested remediation. Do not include real message contents, contact records, phone numbers, or attachment files.
+
+The project aims to acknowledge a report within 72 hours and provide an initial severity assessment within seven days.
+
+## Local trust boundary
+
+This server runs with the permissions of the application that launches it. Full Disk Access can expose private local data beyond Messages, so users should grant it only to a trusted MCP client and review that client's tool confirmations and data policies.

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -28,10 +28,9 @@ python scripts/bump_version.py major
 
 The script will:
 1. Update the version in `pyproject.toml`
-2. Update the version in `mac_messages_mcp/__init__.py`
-3. Update the version in `manifest.json` when the Claude Desktop extension manifest is present
-4. Optionally commit the changes
-5. Optionally create a Git tag
+2. Update the version in `manifest.json` when the Claude Desktop extension manifest is present
+3. Optionally commit the changes
+4. Optionally create a Git tag
 
 ### Publishing a New Version
 
@@ -45,15 +44,16 @@ git push origin vX.Y.Z
 ```
 
 This will trigger the GitHub Actions workflow which will:
-1. Build the package with the new version
-2. Publish it to PyPI
+1. Verify the tag matches `pyproject.toml` and `manifest.json`
+2. Build the package with uv
+3. Publish it to PyPI using trusted publishing
 
 ## Version Files
 
 Versions are stored in the following files:
 
 - `pyproject.toml`: The primary source of version information for the package
-- `mac_messages_mcp/__init__.py`: Contains the `__version__` variable used by the package
+- `mac_messages_mcp/__init__.py`: Reads the installed distribution version dynamically
 - `manifest.json`: Contains the Claude Desktop extension package version
 - Git tags: Used to trigger releases and provide version history
 

--- a/mac_messages_mcp/__init__.py
+++ b/mac_messages_mcp/__init__.py
@@ -2,6 +2,8 @@
 Mac Messages MCP - A bridge for interacting with macOS Messages app
 """
 
+from importlib.metadata import PackageNotFoundError, version
+
 from .messages import (
     check_addressbook_access,
     check_messages_db_access,
@@ -36,4 +38,7 @@ __all__ = [
     "fuzzy_search_messages",
 ]
 
-__version__ = "0.9.2"
+try:
+    __version__ = version("mac-messages-mcp")
+except PackageNotFoundError:
+    __version__ = "0.0.0+local"

--- a/mac_messages_mcp/messages.py
+++ b/mac_messages_mcp/messages.py
@@ -18,7 +18,6 @@ from typing import Any, Dict, List, Optional, Tuple
 from mcp.server.fastmcp import Image
 from thefuzz import fuzz
 
-
 _APPLESCRIPT_TIMEOUT_SECONDS = 30
 
 

--- a/mac_messages_mcp/messages.py
+++ b/mac_messages_mcp/messages.py
@@ -12,18 +12,35 @@ import subprocess
 import tempfile
 import time
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from mcp.server.fastmcp import Image
 from thefuzz import fuzz
 
 
-def run_applescript(script: str) -> str:
+_APPLESCRIPT_TIMEOUT_SECONDS = 30
+
+
+def _connect_sqlite_readonly(path: str) -> sqlite3.Connection:
+    """Open a local SQLite database without write, journal, or creation access."""
+    uri = f"{Path(path).expanduser().resolve().as_uri()}?mode=ro"
+    connection = sqlite3.connect(uri, uri=True)
+    connection.execute("PRAGMA query_only = ON")
+    return connection
+
+
+def run_applescript(script: str, timeout: float = _APPLESCRIPT_TIMEOUT_SECONDS) -> str:
     """Run an AppleScript and return the result."""
     proc = subprocess.Popen(
         ["osascript", "-e", script], stdout=subprocess.PIPE, stderr=subprocess.PIPE
     )
-    out, err = proc.communicate()
+    try:
+        out, err = proc.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.communicate()
+        return f"Error: AppleScript timed out after {timeout:g} seconds"
     if proc.returncode != 0:
         return f"Error: {err.decode('utf-8')}"
     return out.decode("utf-8").strip()
@@ -60,7 +77,7 @@ def get_chat_mapping() -> Dict[str, str]:
     """
     conn = None
     try:
-        conn = sqlite3.connect(get_messages_db_path())
+        conn = _connect_sqlite_readonly(get_messages_db_path())
         cursor = conn.cursor()
         cursor.execute("SELECT room_name, display_name FROM chat")
         result_set = cursor.fetchall()
@@ -166,7 +183,7 @@ def query_messages_db(query: str, params: tuple = ()) -> List[Dict[str, Any]]:
 
         # Try to connect to the database
         try:
-            conn = sqlite3.connect(db_path)
+            conn = _connect_sqlite_readonly(db_path)
         except sqlite3.OperationalError as e:
             return [
                 {
@@ -368,7 +385,7 @@ def query_addressbook_db(query: str, params: tuple = ()) -> List[Dict[str, Any]]
         all_results = []
         for db_path in db_paths:
             try:
-                conn = sqlite3.connect(db_path)
+                conn = _connect_sqlite_readonly(db_path)
                 conn.row_factory = sqlite3.Row
                 cursor = conn.cursor()
                 cursor.execute(query, params)
@@ -1614,7 +1631,7 @@ def check_messages_db_access() -> str:
 
         # Try to connect to the database
         try:
-            conn = sqlite3.connect(db_path)
+            conn = _connect_sqlite_readonly(db_path)
             status.append("Successfully connected to database")
 
             # Test a simple query
@@ -1773,7 +1790,7 @@ def check_addressbook_access() -> str:
 
             # Try to connect to the database
             try:
-                conn = sqlite3.connect(db_path)
+                conn = _connect_sqlite_readonly(db_path)
                 status.append(f"Successfully connected to database: {db_path}")
 
                 # Test a simple query

--- a/main.py
+++ b/main.py
@@ -4,9 +4,11 @@ Mac Messages MCP - Main entry point for the package
 """
 from mac_messages_mcp.server import run_server
 
+
 def main():
     """Entry point for the mac-messages-mcp package"""
     run_server()
+
 
 if __name__ == "__main__":
     main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Operating System :: MacOS :: MacOS X",
     "Topic :: Communications :: Chat",
 ]
@@ -65,3 +67,7 @@ warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true
 disallow_incomplete_defs = true
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = ["--strict-config", "--strict-markers"]

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -73,16 +73,6 @@ def update_files(new_version):
     )
     pyproject_path.write_text(updated_content)
 
-    # Update __init__.py
-    init_path = Path("mac_messages_mcp/__init__.py")
-    content = init_path.read_text()
-    updated_content = re.sub(
-        r'__version__ = "' + VERSION_PATTERN + '"',
-        f'__version__ = "{new_version}"',
-        content,
-    )
-    init_path.write_text(updated_content)
-
     # Update Claude Desktop extension manifest when present
     manifest_path = Path("manifest.json")
     if manifest_path.exists():
@@ -90,9 +80,7 @@ def update_files(new_version):
         manifest["version"] = new_version
         manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
 
-    print(
-        f"Updated version to {new_version} in pyproject.toml, __init__.py, and manifest.json"
-    )
+    print(f"Updated version to {new_version} in pyproject.toml and manifest.json")
 
 
 def create_git_tag(new_version):
@@ -141,7 +129,6 @@ def main():
                 "git",
                 "add",
                 "pyproject.toml",
-                "mac_messages_mcp/__init__.py",
                 "manifest.json",
             ],
             check=True,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,3 @@
 """
 Tests for Mac Messages MCP
-""" 
+"""

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -5,6 +5,7 @@ Style follows the rest of the suite: unittest + mocking. We patch
 query_messages_db to return canned attachment rows and assert that
 filtering, formatting, and progressive-disclosure behaviours all work.
 """
+
 import os
 import unittest
 from unittest.mock import MagicMock, patch
@@ -66,25 +67,31 @@ class TestFilterExcludedAttachments(unittest.TestCase):
         self.assertEqual(_filter_excluded_attachments(rows), [])
 
     def test_drops_plugin_payload_uti(self):
-        rows = [make_attachment_row(
-            uti="com.apple.messages.MSMessageExtensionBalloonPlugin",
-            mime_type=None,
-        )]
+        rows = [
+            make_attachment_row(
+                uti="com.apple.messages.MSMessageExtensionBalloonPlugin",
+                mime_type=None,
+            )
+        ]
         self.assertEqual(_filter_excluded_attachments(rows), [])
 
     def test_drops_pluginpayloadattachment_filename(self):
-        rows = [make_attachment_row(
-            transfer_name="payload.pluginPayloadAttachment",
-            uti=None,
-        )]
+        rows = [
+            make_attachment_row(
+                transfer_name="payload.pluginPayloadAttachment",
+                uti=None,
+            )
+        ]
         self.assertEqual(_filter_excluded_attachments(rows), [])
 
     def test_keeps_pdf(self):
-        rows = [make_attachment_row(
-            mime_type="application/pdf",
-            uti="com.adobe.pdf",
-            transfer_name="letter.pdf",
-        )]
+        rows = [
+            make_attachment_row(
+                mime_type="application/pdf",
+                uti="com.adobe.pdf",
+                transfer_name="letter.pdf",
+            )
+        ]
         self.assertEqual(len(_filter_excluded_attachments(rows)), 1)
 
 
@@ -156,7 +163,7 @@ class TestSearchAttachments(unittest.TestCase):
             ),
         ]
         result = search_attachments()
-        self.assertIn("42", result)         # attachment id is referenceable
+        self.assertIn("42", result)  # attachment id is referenceable
         self.assertIn("image/jpeg", result)  # mime type shown
         self.assertIn("invitation.jpg", result)  # transfer_name shown
 
@@ -178,8 +185,10 @@ class TestSearchAttachments(unittest.TestCase):
         sql, params = call_args[0]
         # Two timestamp params (start, end) + any others
         # Apple ns timestamps should be ints in params
-        self.assertTrue(any(isinstance(p, int) and p > 0 for p in params),
-                        f"Expected an Apple-ns int in params: {params}")
+        self.assertTrue(
+            any(isinstance(p, int) and p > 0 for p in params),
+            f"Expected an Apple-ns int in params: {params}",
+        )
 
     @patch("mac_messages_mcp.messages.get_contact_name", return_value="Someone")
     @patch("mac_messages_mcp.messages.query_messages_db")
@@ -217,7 +226,9 @@ class TestGetAttachment(unittest.TestCase):
     @patch("mac_messages_mcp.messages.os.path.exists", return_value=False)
     @patch("mac_messages_mcp.messages.query_messages_db")
     def test_missing_on_disk_returns_path_with_warning(self, mock_query, _exists):
-        mock_query.return_value = [make_attachment_row(rowid=42, mime_type="image/jpeg")]
+        mock_query.return_value = [
+            make_attachment_row(rowid=42, mime_type="image/jpeg")
+        ]
         result = get_attachment(42)
         self.assertIsInstance(result, str)
         self.assertIn("missing", result.lower())
@@ -226,12 +237,14 @@ class TestGetAttachment(unittest.TestCase):
     @patch("mac_messages_mcp.messages.os.path.exists", return_value=True)
     @patch("mac_messages_mcp.messages.query_messages_db")
     def test_pdf_returns_path_metadata_text(self, mock_query, _exists, _size):
-        mock_query.return_value = [make_attachment_row(
-            rowid=42,
-            mime_type="application/pdf",
-            transfer_name="letter.pdf",
-            uti="com.adobe.pdf",
-        )]
+        mock_query.return_value = [
+            make_attachment_row(
+                rowid=42,
+                mime_type="application/pdf",
+                transfer_name="letter.pdf",
+                uti="com.adobe.pdf",
+            )
+        ]
         result = get_attachment(42)
         # PDF → string (path metadata), not an Image
         self.assertIsInstance(result, str)
@@ -244,12 +257,14 @@ class TestGetAttachment(unittest.TestCase):
     @patch("mac_messages_mcp.messages.os.path.exists", return_value=True)
     @patch("mac_messages_mcp.messages.query_messages_db")
     def test_oversize_image_falls_back_to_path(self, mock_query, _exists, _size):
-        mock_query.return_value = [make_attachment_row(
-            rowid=42,
-            mime_type="image/jpeg",
-            transfer_name="big.jpg",
-            total_bytes=10_000_000,
-        )]
+        mock_query.return_value = [
+            make_attachment_row(
+                rowid=42,
+                mime_type="image/jpeg",
+                transfer_name="big.jpg",
+                total_bytes=10_000_000,
+            )
+        ]
         result = get_attachment(42, max_bytes=5_000_000)
         # Path-only string return (no inline bytes), but path must still be there
         self.assertIsInstance(result, str)
@@ -266,20 +281,21 @@ class TestGetAttachment(unittest.TestCase):
         # One-pixel valid JPEG
         jpeg_bytes = bytes.fromhex(
             "ffd8ffe000104a46494600010100000100010000ffdb0043000806060706050806070707"
-            "09090808"
-            + "0a" * 50
-            + "ffd9"
+            "09090808" + "0a" * 50 + "ffd9"
         )
         with patch("builtins.open", unittest.mock.mock_open(read_data=jpeg_bytes)):
-            mock_query.return_value = [make_attachment_row(
-                rowid=42,
-                mime_type="image/jpeg",
-                transfer_name="photo.jpg",
-                total_bytes=200,
-            )]
+            mock_query.return_value = [
+                make_attachment_row(
+                    rowid=42,
+                    mime_type="image/jpeg",
+                    transfer_name="photo.jpg",
+                    total_bytes=200,
+                )
+            ]
             result = get_attachment(42)
         # Returns a list: [metadata_text, Image]
         from mcp.server.fastmcp import Image
+
         self.assertIsInstance(result, list)
         self.assertEqual(len(result), 2)
         text = next((x for x in result if isinstance(x, str)), None)
@@ -299,18 +315,22 @@ class TestFormatAttachmentSummary(unittest.TestCase):
         self.assertEqual(_format_attachment_summary([]), "")
 
     def test_single_attachment(self):
-        line = _format_attachment_summary([
-            {"id": 42, "mime_type": "image/jpeg", "filename": "photo.jpg"},
-        ])
+        line = _format_attachment_summary(
+            [
+                {"id": 42, "mime_type": "image/jpeg", "filename": "photo.jpg"},
+            ]
+        )
         # Should mention id and mime_type at minimum so agent can call get_attachment
         self.assertIn("42", line)
         self.assertIn("image/jpeg", line)
 
     def test_multiple_attachments_short(self):
-        line = _format_attachment_summary([
-            {"id": 1, "mime_type": "image/jpeg", "filename": "a.jpg"},
-            {"id": 2, "mime_type": "image/heic", "filename": "b.heic"},
-        ])
+        line = _format_attachment_summary(
+            [
+                {"id": 1, "mime_type": "image/jpeg", "filename": "a.jpg"},
+                {"id": 2, "mime_type": "image/heic", "filename": "b.heic"},
+            ]
+        )
         # Both ids surface
         self.assertIn("1", line)
         self.assertIn("2", line)

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -4,11 +4,13 @@ Tests for the messages module
 
 import os
 import sqlite3
+import subprocess
 import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
 
 from mac_messages_mcp.messages import (
+    _connect_sqlite_readonly,
     _find_chat_by_identifier,
     _format_phone_for_messages,
     _sanitize_message_body,
@@ -47,6 +49,7 @@ class TestMessages(unittest.TestCase):
             stdout=-1,
             stderr=-1,
         )
+        process_mock.communicate.assert_called_once_with(timeout=30)
 
     @patch("subprocess.Popen")
     def test_run_applescript_error(self, mock_popen):
@@ -62,6 +65,37 @@ class TestMessages(unittest.TestCase):
 
         # Check results
         self.assertEqual(result, "Error: Error message")
+
+    @patch("subprocess.Popen")
+    def test_run_applescript_timeout_kills_process(self, mock_popen):
+        process_mock = MagicMock()
+        process_mock.communicate.side_effect = [
+            subprocess.TimeoutExpired(cmd="osascript", timeout=1),
+            (b"", b""),
+        ]
+        mock_popen.return_value = process_mock
+
+        result = run_applescript("delay 10", timeout=1)
+
+        self.assertEqual(result, "Error: AppleScript timed out after 1 seconds")
+        process_mock.kill.assert_called_once_with()
+
+    def test_readonly_connection_rejects_writes(self):
+        with tempfile.TemporaryDirectory() as directory:
+            db_path = os.path.join(directory, "messages.db")
+            writable = sqlite3.connect(db_path)
+            writable.execute("CREATE TABLE message (id INTEGER)")
+            writable.commit()
+            writable.close()
+
+            connection = _connect_sqlite_readonly(db_path)
+            self.assertEqual(
+                connection.execute("SELECT name FROM sqlite_master").fetchone()[0],
+                "message",
+            )
+            with self.assertRaises(sqlite3.OperationalError):
+                connection.execute("INSERT INTO message VALUES (1)")
+            connection.close()
 
     @patch("os.path.expanduser")
     def test_get_messages_db_path(self, mock_expanduser):

--- a/tests/test_timestamp_helpers.py
+++ b/tests/test_timestamp_helpers.py
@@ -11,6 +11,7 @@ refactor (centralising the inline math into shared helpers) can be
 validated as behaviour-preserving rather than relying on it being
 written correctly by inspection.
 """
+
 import calendar
 import unittest
 from datetime import datetime, timedelta, timezone
@@ -22,7 +23,6 @@ from mac_messages_mcp.messages import (
     fuzzy_search_messages,
     get_recent_messages,
 )
-
 
 # A specific datetime we'll use across multiple tests. Reference values
 # are derived via the Unix epoch and a single 1970->2001 offset so they
@@ -67,6 +67,7 @@ class TestFromAppleNs(unittest.TestCase):
     def setUp(self):
         try:
             from mac_messages_mcp.messages import _from_apple_ns
+
             self._from_apple_ns = _from_apple_ns
         except ImportError as e:
             self.skipTest(f"_from_apple_ns not yet defined: {e}")
@@ -164,10 +165,12 @@ class TestFuzzySearchTimestampParam(unittest.TestCase):
         expected_high = _to_apple_ns(after - timedelta(hours=24))
         # Allow up to 1 second of slop for the now() drift between
         # before/after measurements.
-        self.assertGreaterEqual(cutoff_ns, expected_low - 10**9,
-                                f"cutoff {cutoff_ns} too small")
-        self.assertLessEqual(cutoff_ns, expected_high + 10**9,
-                             f"cutoff {cutoff_ns} too large")
+        self.assertGreaterEqual(
+            cutoff_ns, expected_low - 10**9, f"cutoff {cutoff_ns} too small"
+        )
+        self.assertLessEqual(
+            cutoff_ns, expected_high + 10**9, f"cutoff {cutoff_ns} too large"
+        )
 
     @patch("mac_messages_mcp.messages._attachments_for_message_ids", return_value={})
     @patch("mac_messages_mcp.messages.get_chat_mapping", return_value={})


### PR DESCRIPTION
## What changed

- open Messages and Contacts SQLite databases in URI read-only mode with `query_only`
- bound AppleScript execution to 30 seconds and kill timed-out processes
- add regression tests for database writes and AppleScript timeouts
- add a macOS/Python UV test matrix and package-install smoke job
- pin GitHub Actions and UV versions
- move PyPI publishing to UV trusted publishing and verify tag/package/manifest versions
- derive `__version__` from installed package metadata
- normalize existing Python formatting so CI starts green
- simplify README badges and add security, privacy, and contributor documentation

## Why

The server only needs to read local Apple databases, but ordinary SQLite connections can create files or journals and AppleScript could hang indefinitely. The release path also had no test gate and rewrote version files during publication.

## Validation

- `uv run --frozen --extra dev pytest` — 114 tests passed
- Black check — 12 files clean
- isort check
- `uv build` — source distribution and wheel built successfully
- package and manifest versions both resolve to 0.9.2
- `git diff --check`

## Release setup

PyPI trusted publishing must authorize this repository's `publish.yml` workflow before the next tag.

Part of #56.