### PR TITLE
docs: overhaul README and MCP setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,297 +1,453 @@
 # Mac Messages MCP
 
-A local-first Model Context Protocol server for reading, searching, and sending through the macOS Messages app.
+Use Claude, Codex, Cursor, VS Code, or any local MCP client to search, read, and
+send messages through the macOS Messages app.
 
-[![PyPI](https://img.shields.io/pypi/v/mac-messages-mcp)](https://pypi.org/project/mac-messages-mcp/)
-[![Python](https://img.shields.io/pypi/pyversions/mac-messages-mcp)](https://pypi.org/project/mac-messages-mcp/)
+[![PyPI](https://img.shields.io/pypi/v/mac-messages-mcp?logo=pypi&logoColor=white)](https://pypi.org/project/mac-messages-mcp/)
+[![Python](https://img.shields.io/pypi/pyversions/mac-messages-mcp?logo=python&logoColor=white)](https://pypi.org/project/mac-messages-mcp/)
 [![CI](https://github.com/carterlasalle/mac_messages_mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/carterlasalle/mac_messages_mcp/actions/workflows/ci.yml)
+[![Downloads](https://static.pepy.tech/badge/mac-messages-mcp)](https://pepy.tech/project/mac-messages-mcp)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-![a-diagram-of-a-mac-computer-with-the-tex_FvvnmbaBTFeKy6F2GMlLqA_IfCBMgJARcia1WTH7FaqwA](https://github.com/user-attachments/assets/dbbdaa14-fadd-434d-a265-9e0c0071c11d)
+Mac Messages MCP runs locally on your Mac. It opens the Messages and Contacts
+databases read-only, returns only the data a client asks for, and uses
+Messages.app automation only when the client explicitly calls the send tool.
 
-Messages and contacts stay on the Mac where this server runs. Database connections are opened read-only; sending is a separate, explicit tool that uses Messages.app automation.
+> [!IMPORTANT] This server is macOS-only. Reading messages requires Full Disk
+> Access. Sending requires a Mac signed into Messages plus permission for the
+> launching app to automate Messages.
 
-## Quick Install
+## What it can do
 
-### For Cursor Users
+- Read recent messages across all conversations or filter by contact or group
+  chat
+- Fuzzy-search message text across a time window, including all available
+  history
+- Find Contacts by approximate name and return send-ready phone numbers
+- List named group chats and use their chat IDs for reads or sends
+- Send iMessage, with SMS/RCS fallback for eligible phone recipients
+- Check whether a recipient appears reachable through iMessage before sending
+- Find attachments by date, sender, and MIME type
+- Return small images inline, convert HEIC images to PNG, or return a local path
+  for larger and non-image files
+- Diagnose Messages and Contacts database permissions from inside the MCP client
 
-[![Install MCP Server](https://cursor.com/deeplink/mcp-install-light.svg)](https://cursor.com/install-mcp?name=mac-messages-mcp&config=eyJjb21tYW5kIjoidXZ4IG1hYy1tZXNzYWdlcy1tY3AifQ%3D%3D)
+## Quick start
 
-*Click the button above to automatically add Mac Messages MCP to Cursor*
-
-### For Claude Desktop Users
-
-See the [Integration section](#integration) below for setup instructions.
-
-## Features
-
-- **Universal Message Sending**: Automatically sends via iMessage or SMS/RCS based on recipient availability
-- **Smart Fallback**: Seamless fallback to SMS when iMessage is unavailable (perfect for Android users)
-- **Message Reading**: Read recent messages from the macOS Messages app
-- **Contact Filtering**: Filter messages by specific contacts or phone numbers
-- **Group Chat Filtering**: Use chat IDs from `tool_get_chats` to read one group conversation chronologically
-- **Fuzzy Search**: Search through message content with intelligent matching
-- **Attachments**: Find and view photos, PDFs, and other attachments shared in conversations
-- **iMessage Detection**: Check if recipients have iMessage before sending
-- **Cross-Platform**: Works with both iPhone/Mac users (iMessage) and Android users (SMS/RCS)
-
-### Working with attachments
-
-Attachment access uses **progressive disclosure** — discovery is cheap, fetching is deliberate:
-
-1. **Tier 1 — discovery in message search.** `tool_get_recent_messages` and `tool_fuzzy_search_messages` annotate messages that have attachments with a compact summary like `[attachments: #42 image/jpeg (invitation.jpg)]`. The id lets you fetch the file later.
-2. **Tier 2 — attachment-first search.** `tool_search_attachments(start_date, end_date, contact, mime_type, limit)` returns metadata only (id, MIME type, filename, size, sender) — useful for "find all images Elizabeth sent in April 2026" without scanning message text.
-3. **Tier 3 — fetch.** `tool_get_attachment(attachment_id)` returns the file. Image MIME types come back inline (HEIC is converted to PNG so it can be viewed directly). PDFs, video, and audio come back as a filesystem path the agent can read with its own tools. Inline image bytes are capped at 5MB by default to avoid context blowup; oversized images fall back to path return.
-
-Stickers, link-preview "balloon" payloads, and `.pluginPayloadAttachment` containers are filtered out by default.
-
-### Recipient formats
-
-For direct sends, E.164 phone numbers with a leading `+` are the most reliable format, such as `+14155551234`. Bare digit phone numbers with a country code are normalized before sending, and 10-digit US numbers are sent as `+1...`. `tool_find_contact` returns phone matches in the same send-ready format.
-
-## Prerequisites
-
-- macOS (tested on macOS 11+)
-- Python 3.10+
-- **uv package manager**
-
-## Security and privacy model
-
-- Message and Contacts databases are opened with SQLite `mode=ro` and `query_only` enabled.
-- The server does not upload a message archive or maintain its own copy of the databases.
-- MCP clients receive only tool results requested in the current session. Attachment retrieval is deliberate and size limited.
-- Sending requires an explicit `tool_send_message` call and uses escaped AppleScript values with a bounded execution timeout.
-- Full Disk Access is powerful. Grant it only to the specific trusted client that launches this server.
-
-See [SECURITY.md](SECURITY.md) for private vulnerability reporting.
-
-### Installing uv
-
-If you're on Mac, install uv using Homebrew:
+### 1. Install `uv`
 
 ```bash
 brew install uv
 ```
 
-Otherwise, follow the installation instructions on the [uv website](https://github.com/astral-sh/uv).
-
-⚠️ **Do not proceed before installing uv**
-
-## Installation
-
-### Full Disk Access Permission
-
-⚠️ This application requires **Full Disk Access** permission for your terminal or application to access the Messages database. 
-
-To grant Full Disk Access:
-1. Open **System Preferences/Settings** > **Security & Privacy/Privacy** > **Full Disk Access**
-2. Click the lock icon to make changes
-3. Add your terminal app (Terminal, iTerm2, etc.) or Claude Desktop/Cursor to the list
-4. Restart your terminal or application after granting permission
-
-## Integration
-
-### Claude Desktop Integration
-
-#### Option 1: Claude Desktop Extension
-
-This repo includes an MCPB-compatible `manifest.json` for Claude Desktop's one-click extension flow.
+Confirm that the launcher is available:
 
 ```bash
-yarn global add @anthropic-ai/mcpb
-mcpb pack
+uvx --version
 ```
 
-Install the generated `.mcpb` file from Claude Desktop **Settings** > **Extensions** > **Advanced settings** > **Install Extension...**.
+Python 3.10 or newer is required. `uvx` can provision a compatible Python and
+installs Mac Messages MCP in an isolated environment, so you do not need to
+create a virtual environment first.
 
-Claude Desktop, or the terminal used to package/run the extension, still needs Full Disk Access to read Messages.
+### 2. Grant macOS permissions
 
-**Building the extension**
+Open **System Settings → Privacy & Security → Full Disk Access** and enable the
+app that will launch the MCP server:
 
-Build the `.mcpb` with the build script:
+- Claude Desktop, Cursor, VS Code, or the ChatGPT desktop app when configured in
+  that app
+- Terminal, iTerm2, Ghostty, or another terminal when using Claude Code or Codex
+  CLI from that terminal
 
-```bash
-python scripts/build_mcpb.py                  # build for the host architecture
-python scripts/build_mcpb.py --arch x86_64    # build for Intel macs
-```
+Quit and reopen the app after changing Full Disk Access. On the first contact
+lookup or send, macOS may separately ask for access to Contacts or permission to
+control Messages. Allow those prompts.
 
-By default it vendors a `uv` binary into the bundle (`bin/uv`) so the extension also runs on machines without `uv` installed — that binary is architecture specific (build one `.mcpb` per arch) and downloads Python and dependencies on first launch (network required once). Pass `--no-bundle` to pack against the system `uv` instead; see `python scripts/build_mcpb.py --help` for all options.
+Also make sure Messages.app is open, signed in, and already able to send a
+normal message.
 
-#### Option 2: Manual Config
+### 3. Add the server to your MCP client
 
-1. Go to **Claude** > **Settings** > **Developer** > **Edit Config** > **claude_desktop_config.json**
-2. Add the following configuration:
+The server command is the same everywhere:
 
-```json
-{
-    "mcpServers": {
-        "messages": {
-            "command": "uvx",
-            "args": [
-                "mac-messages-mcp"
-            ]
-        }
-    }
-}
-```
-
-### Cursor Integration
-
-#### Option 1: One-Click Install (Recommended)
-
-[![Install MCP Server](https://cursor.com/deeplink/mcp-install-light.svg)](https://cursor.com/install-mcp?name=mac-messages-mcp&config=eyJjb21tYW5kIjoidXZ4IG1hYy1tZXNzYWdlcy1tY3AifQ%3D%3D)
-
-#### Option 2: Manual Setup
-
-Go to **Cursor Settings** > **MCP** and paste this as a command:
-
-```
+```text
 uvx mac-messages-mcp
 ```
 
-⚠️ Only run one instance of the MCP server (either on Cursor or Claude Desktop), not both
+Choose your client below.
 
-### Docker Container Integration
+#### Claude Desktop
 
-If you need to connect to `mac-messages-mcp` from a Docker container, you'll need to use the `mcp-proxy` package to bridge the stdio-based server to HTTP.
+Open **Claude → Settings → Developer → Edit Config**, then add:
 
-This repository also includes a `Dockerfile` for catalog checks and container builds:
+```json
+{
+  "mcpServers": {
+    "mac-messages": {
+      "command": "uvx",
+      "args": ["mac-messages-mcp"]
+    }
+  }
+}
+```
+
+Preserve any other servers already in `claude_desktop_config.json`, save the
+file, and restart Claude Desktop.
+
+Claude Desktop also supports installable `.mcpb` extensions. See
+[Build the Claude Desktop extension](#build-the-claude-desktop-extension) if you
+want to package this repository as one.
+
+#### Claude Code
+
+Add it once at user scope so it is available in every project:
 
 ```bash
-docker build -t mac-messages-mcp .
+claude mcp add --transport stdio --scope user mac-messages -- uvx mac-messages-mcp
 ```
 
-Messages.app automation is macOS-only and will not work inside a Linux container. Container use is primarily for MCP catalog compatibility and read-only database experiments with mounted data.
-
-#### Setup Instructions
-
-1. **Install mcp-proxy on your macOS host:**
-```bash
-npm install -g mcp-proxy
-```
-
-2. **Start the proxy server:**
-```bash
-# Using the published version
-npx mcp-proxy uvx mac-messages-mcp --port 8000 --host 0.0.0.0
-
-# Or using local development (if you encounter issues)
-npx mcp-proxy uv run python -m mac_messages_mcp.server --port 8000 --host 0.0.0.0
-```
-
-3. **Connect from Docker:**
-Your Docker container can now connect to:
-- URL: `http://host.docker.internal:8000/mcp` (on macOS/Windows)
-- URL: `http://<host-ip>:8000/mcp` (on Linux)
-
-4. **Docker Compose example:**
-```yaml
-version: '3.8'
-services:
-  your-app:
-    image: your-image
-    environment:
-      MCP_MESSAGES_URL: "http://host.docker.internal:8000/mcp"
-    extra_hosts:
-      - "host.docker.internal:host-gateway"  # For Linux hosts
-```
-
-5. **Running multiple MCP servers:**
-```bash
-# Terminal 1 - Messages MCP on port 8001
-npx mcp-proxy uvx mac-messages-mcp --port 8001 --host 0.0.0.0
-
-# Terminal 2 - Another MCP server on port 8002
-npx mcp-proxy uvx another-mcp-server --port 8002 --host 0.0.0.0
-```
-
-**Note:** Binding to `0.0.0.0` exposes the service to all network interfaces. In production, consider using more restrictive host bindings and adding authentication.
-
-
-### Option 1: Install from PyPI
+Verify it:
 
 ```bash
-uv pip install mac-messages-mcp
+claude mcp get mac-messages
 ```
 
-### Option 2: Install from source
+Inside Claude Code, run `/mcp` to inspect the connection and tools.
+
+#### Codex CLI, Codex IDE extension, and ChatGPT desktop app
+
+Codex clients on the same Mac share MCP configuration. Add the server with:
 
 ```bash
-# Clone the repository
-git clone https://github.com/carterlasalle/mac_messages_mcp.git
-cd mac_messages_mcp
-
-# Install dependencies
-uv install -e .
+codex mcp add mac-messages -- uvx mac-messages-mcp
 ```
 
+Then verify it:
 
-## Usage
-
-### Smart Message Delivery
-
-Mac Messages MCP automatically handles message delivery across different platforms:
-
-- **iMessage Users** (iPhone, iPad, Mac): Messages sent via iMessage
-- **Android Users**: Messages automatically fall back to SMS/RCS
-- **Mixed Groups**: Optimal delivery method chosen per recipient
-
-```python
-# Send to iPhone user - uses iMessage
-send_message("+1234567890", "Hey! This goes via iMessage")
-
-# Send to Android user - automatically uses SMS
-send_message("+1987654321", "Hey! This goes via SMS") 
-
-# Check delivery method before sending
-check_imessage_availability("+1234567890")  # Returns availability status
+```bash
+codex mcp list
 ```
 
-### As a Module
+You can also add it directly to `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.mac-messages]
+command = "uvx"
+args = ["mac-messages-mcp"]
+```
+
+Restart the desktop app or IDE extension after changing the configuration. In
+Codex CLI, use `/mcp` to view the active server.
+
+#### Cursor
+
+[![Install MCP Server](https://cursor.com/deeplink/mcp-install-light.svg)](https://cursor.com/install-mcp?name=mac-messages-mcp&config=eyJjb21tYW5kIjoidXZ4IG1hYy1tZXNzYWdlcy1tY3AifQ%3D%3D)
+
+Or open **Cursor Settings → Tools & MCP → New MCP Server** and use:
+
+```json
+{
+  "mcpServers": {
+    "mac-messages": {
+      "command": "uvx",
+      "args": ["mac-messages-mcp"]
+    }
+  }
+}
+```
+
+Restart the server from Cursor's MCP settings after saving.
+
+#### VS Code / GitHub Copilot
+
+Open the Command Palette and run **MCP: Add Server**. Choose **Command
+(stdio)**, enter `uvx` as the command, add `mac-messages-mcp` as the argument,
+and install it globally.
+
+Or add it from a terminal:
+
+```bash
+code --add-mcp '{"name":"mac-messages","command":"uvx","args":["mac-messages-mcp"]}'
+```
+
+The equivalent user or workspace `mcp.json` entry is:
+
+```json
+{
+  "servers": {
+    "mac-messages": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["mac-messages-mcp"]
+    }
+  }
+}
+```
+
+> [!NOTE] VS Code uses a top-level `servers` object. Claude Desktop and Cursor
+> use `mcpServers`.
+
+#### Other stdio MCP clients
+
+Use this generic server definition:
+
+```json
+{
+  "command": "uvx",
+  "args": ["mac-messages-mcp"]
+}
+```
+
+If a GUI client reports that `uvx` cannot be found, run `which uvx` in Terminal
+and replace `"uvx"` with the returned absolute path. Homebrew commonly installs
+it at `/opt/homebrew/bin/uvx` on Apple silicon and `/usr/local/bin/uvx` on Intel
+Macs.
+
+### 4. Verify the connection
+
+Ask your client to call `tool_check_db_access`, then `tool_check_addressbook`.
+Once both succeed, try prompts such as:
+
+```text
+Show me my messages from the last two hours.
+```
+
+```text
+Find messages from Carter about dinner in the last 30 days.
+```
+
+```text
+Find PDFs sent to me this month, but do not open any yet.
+```
+
+```text
+Find Jordan in my contacts and draft a message saying I am running 10 minutes
+late. Do not send it until I confirm.
+```
+
+The first `uvx` launch can take longer while it downloads and caches Python
+dependencies.
+
+## Available tools
+
+<!-- markdownlint-disable MD013 -->
+
+| Tool                               | Purpose                                                                                                | Side effect              |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------ | ------------------------ |
+| `tool_get_recent_messages`         | Read recent messages, optionally filtered by contact or group chat ID                                  | Read-only                |
+| `tool_fuzzy_search_messages`       | Search message bodies by approximate text match; defaults to 30 days, or use `hours=0` for all history | Read-only                |
+| `tool_find_contact`                | Fuzzy-match a name in Contacts and return phone numbers                                                | Read-only                |
+| `tool_get_chats`                   | List named group chats and their identifiers                                                           | Read-only                |
+| `tool_search_attachments`          | Find attachment metadata by date, contact, MIME type, and limit                                        | Read-only                |
+| `tool_get_attachment`              | Fetch one attachment by ID, inline when supported or as a local path                                   | Read-only                |
+| `tool_check_imessage_availability` | Check likely iMessage availability for a phone number or email                                         | Read-only                |
+| `tool_check_db_access`             | Diagnose access to `~/Library/Messages/chat.db`                                                        | Read-only                |
+| `tool_check_contacts`              | Return a contact count and a small sample                                                              | Read-only                |
+| `tool_check_addressbook`           | Diagnose Contacts/AddressBook database access                                                          | Read-only                |
+| `tool_send_message`                | Send one direct or group message through Messages.app                                                  | **Sends a real message** |
+
+<!-- markdownlint-enable MD013 -->
+
+The server also exposes two MCP resources:
+
+- `messages://recent/{hours}`
+- `messages://contact/{contact}/{hours}`
+
+## Working with contacts, chats, and attachments
+
+### Recipients
+
+For direct messages, E.164 phone numbers are the most reliable format:
+
+```text
++14155551234
+```
+
+The server normalizes bare numbers with a country code and converts 10-digit US
+numbers to `+1...`. It also accepts email addresses, contact names, and
+`contact:N` selections returned after an ambiguous contact search.
+
+For a group conversation, call `tool_get_chats`, pass its chat ID to
+`tool_send_message`, and set `group_chat=true`. Use the same ID as `chat_id` in
+`tool_get_recent_messages` to read that conversation.
+
+### Attachments
+
+Attachment access is deliberately split into three steps:
+
+1. Message reads and searches add compact markers such as
+   `[attachments: #42 image/jpeg (invitation.jpg)]`.
+2. `tool_search_attachments` searches metadata without loading file contents.
+3. `tool_get_attachment` fetches one selected attachment.
+
+Images up to 5 MB are returned inline by default. HEIC images are converted to
+PNG. Larger images, PDFs, video, and audio are returned as local filesystem
+paths so the MCP client can decide whether to open them. Stickers, link-preview
+payloads, and `.pluginPayloadAttachment` containers are filtered out.
+
+## Privacy and security
+
+- Messages and Contacts SQLite connections use read-only mode and SQLite
+  `query_only`.
+- The server does not upload, mirror, index, or maintain its own message
+  archive.
+- Results are written to the local MCP stdio connection started by your client.
+- Message bodies are sanitized and bounded before being returned.
+- Attachment bytes are returned only after an explicit fetch and are
+  size-limited for inline images.
+- Sending is isolated in `tool_send_message`, escapes AppleScript inputs, and
+  uses a bounded execution timeout.
+- Full Disk Access is broader than Messages access. Grant it only to MCP clients
+  you trust and review the destination before approving a send.
+
+See [SECURITY.md](SECURITY.md) to report a vulnerability privately.
+
+## Troubleshooting
+
+### `uvx` or `spawn uvx ENOENT`
+
+The GUI app cannot see your shell's Homebrew path. Run:
+
+```bash
+which uvx
+```
+
+Use that full path as the MCP `command`, then restart the client.
+
+### `Operation not permitted`, `unable to open database file`, or no messages
+
+Grant Full Disk Access to the app that launches the server, not just to
+Messages.app. Completely quit and reopen the launcher afterward, then call
+`tool_check_db_access` again.
+
+For Claude Code or Codex CLI, the launcher is normally your terminal. For a
+desktop or IDE integration, it is normally Claude Desktop, Cursor, VS Code, or
+the ChatGPT desktop app itself.
+
+### Contacts are empty or contact lookup fails
+
+Allow the launching app to access Contacts if macOS prompts. Confirm Full Disk
+Access, restart the app, and call `tool_check_addressbook` followed by
+`tool_check_contacts`.
+
+### Reading works but sending fails
+
+1. Open Messages.app and send a message manually to confirm the account and
+   recipient work.
+2. Check **System Settings → Privacy & Security → Automation** and allow the
+   launching app to control Messages.
+3. Prefer an E.164 number such as `+14155551234` for a direct recipient.
+4. Use `tool_check_imessage_availability` to inspect the likely route.
+
+### An attachment is listed but cannot be opened
+
+Messages may retain database metadata after macOS has offloaded the file. Open
+the conversation in Messages.app and download the attachment, then retry
+`tool_get_attachment`.
+
+### The server appears to hang when run in Terminal
+
+That is normal for an MCP stdio server: it waits for protocol input from a
+client. Use your client's MCP status view, or launch the MCP Inspector:
+
+```bash
+yarn dlx @modelcontextprotocol/inspector uvx mac-messages-mcp
+```
+
+## Install as a standalone tool
+
+MCP clients can launch the package directly with `uvx`; a permanent installation
+is optional.
+
+```bash
+uv tool install mac-messages-mcp
+mac-messages-mcp
+```
+
+Upgrade or remove it with:
+
+```bash
+uv tool upgrade mac-messages-mcp
+uv tool uninstall mac-messages-mcp
+```
+
+## Python API
+
+The MCP server is the primary interface, but the package also exports its core
+read/send functions:
 
 ```python
 from mac_messages_mcp import get_recent_messages, send_message
 
-# Get recent messages
-messages = get_recent_messages(hours=48)
-print(messages)
+recent = get_recent_messages(hours=48)
+print(recent)
 
-# Send a message (automatically chooses iMessage or SMS)
-result = send_message(recipient="+1234567890", message="Hello from Mac Messages MCP!")
-print(result)  # Shows whether sent via iMessage or SMS
+result = send_message(
+    recipient="+14155551234",
+    message="Hello from Mac Messages MCP!",
+)
+print(result)
 ```
 
-### As a Command-Line Tool
-
-```bash
-# Run the MCP server directly
-mac-messages-mcp
-```
+These calls use the same macOS permissions and can send real messages.
 
 ## Development
 
-### Versioning
-
-This project uses semantic versioning. See [VERSIONING.md](VERSIONING.md) for details on how the versioning system works and how to release new versions.
-
-To bump the version:
-
 ```bash
-python scripts/bump_version.py [patch|minor|major]
+git clone https://github.com/carterlasalle/mac_messages_mcp.git
+cd mac_messages_mcp
+
+uv sync --frozen --extra dev
+uv run pytest
+uv run black --check .
+uv run isort --check-only .
+uv build
 ```
 
-## Security Notes
+Tests mock AppleScript and use temporary database fixtures; they must never read
+a contributor's real Messages or Contacts data. See
+[CONTRIBUTING.md](CONTRIBUTING.md) for the contribution checklist and
+[VERSIONING.md](VERSIONING.md) for releases.
 
-This application accesses the Messages database directly, which contains personal communications. Please use it responsibly and ensure you have appropriate permissions.
+### Build the Claude Desktop extension
 
-[![MseeP.ai Security Assessment Badge](https://mseep.net/pr/carterlasalle-mac-messages-mcp-badge.png)](https://mseep.ai/app/carterlasalle-mac-messages-mcp)
+The repository includes an MCPB `manifest.json` and a build script that can
+bundle an architecture-specific `uv` binary:
+
+```bash
+yarn global add @anthropic-ai/mcpb
+uv run python scripts/build_mcpb.py
+```
+
+For an Intel build:
+
+```bash
+uv run python scripts/build_mcpb.py --arch x86_64
+```
+
+Install the generated `.mcpb` from **Claude Desktop → Settings → Extensions →
+Advanced settings → Install Extension…**. A bundled extension still needs
+network access on first launch to download Python and the package dependencies.
+
+Use `--no-bundle` to package against the system `uv`, or run
+`uv run python scripts/build_mcpb.py --help` for every option.
+
+## Docker
+
+The included Dockerfile is for package and catalog validation. A Linux container
+cannot access macOS TCC permissions or automate Messages.app, so Docker is not a
+supported way to read or send messages on the host Mac.
 
 ## License
 
-MIT
+[MIT](LICENSE) © Carter Lasalle
 
 ## Contributing
 
-Contributions are welcome! Please feel free to submit a Pull Request. 
-## Star History
+Issues and focused pull requests are welcome. Do not include real message
+contents, contacts, phone numbers, database files, or attachments in bug reports
+or fixtures.
 
-[![Star History Chart](https://api.star-history.com/svg?repos=carterlasalle/mac_messages_mcp&type=Date)](https://www.star-history.com/#carterlasalle/mac_messages_mcp&Date)
+[Changelog](CHANGELOG.md) · [Contributing](CONTRIBUTING.md) ·
+[Security](SECURITY.md) · [PyPI](https://pypi.org/project/mac-messages-mcp/)


### PR DESCRIPTION
## What changed

- Rebuilt the README around a four-step installation and verification flow.
- Added current setup instructions for Claude Desktop, Claude Code, Codex CLI/IDE/desktop, Cursor, VS Code, and generic stdio MCP clients.
- Documented all 11 MCP tools, both resources, macOS permission requirements, contact/group-chat behavior, attachment handling, privacy boundaries, and common failures.
- Replaced the invalid source-install command with the repository's real `uv sync --frozen --extra dev` workflow.
- Reframed Docker as package/catalog validation because Linux containers cannot use macOS TCC or automate Messages.app.
- Added accurate MCPB build instructions and a focused Python API example.

## Why

The previous README mixed obsolete client flows, implementation examples, development setup, and a misleading Docker proxy path. It also omitted modern Codex, Claude Code, and VS Code configuration. The new structure follows the actual code and packaging metadata in `main`, so users can get from installation to a working permission check without guessing.

## User impact

New users get one consistent `uvx mac-messages-mcp` launch command, client-specific configuration they can paste, and concrete recovery steps for PATH, Full Disk Access, Contacts, Automation, and offloaded attachments. Existing users get a complete tool reference without any runtime or API behavior change.

## Validation

- Read the server, message backend, packaging metadata, manifest, build/release scripts, CI workflows, security docs, and test suite.
- Verified the published PyPI version and requirements.
- Cross-checked current official MCP setup guidance for Claude, Codex, and VS Code.
- Ran `markdownlint-cli2 README.md`: 0 issues.
- Verified the GitHub branch copy exactly matches the locally validated README.
