### PR TITLE
release: Mac Messages MCP v1.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,34 @@ jobs:
       - name: Test
         run: uv run --frozen --extra dev --python ${{ matrix.python-version }} pytest
 
+  format-diagnostics:
+    name: Black (${{ matrix.path }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        path:
+          - main.py
+          - mac_messages_mcp/__init__.py
+          - mac_messages_mcp/messages.py
+          - mac_messages_mcp/server.py
+          - scripts/build_mcpb.py
+          - scripts/bump_version.py
+          - tests/test_attachments.py
+          - tests/test_fuzzy_search.py
+          - tests/test_integration.py
+          - tests/test_messages.py
+          - tests/test_timestamp_helpers.py
+          - tests/test_versioning.py
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          version: "0.9.25"
+          enable-cache: true
+      - name: Check file
+        run: uvx --from black==25.1.0 black --check "${{ matrix.path }}"
+
   quality-and-package:
     runs-on: macos-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
           enable-cache: true
       - name: Install dependencies
         run: uv sync --frozen --extra dev --python 3.13
+      - name: Verify version metadata
+        run: uv run --frozen --extra dev python scripts/bump_version.py --check --ignore-lock
       - name: Formatting
         run: |
           uv run --frozen --extra dev black --check .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,34 +32,6 @@ jobs:
       - name: Test
         run: uv run --frozen --extra dev --python ${{ matrix.python-version }} pytest
 
-  format-diagnostics:
-    name: Black (${{ matrix.path }})
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        path:
-          - main.py
-          - mac_messages_mcp/__init__.py
-          - mac_messages_mcp/messages.py
-          - mac_messages_mcp/server.py
-          - scripts/build_mcpb.py
-          - scripts/bump_version.py
-          - tests/test_attachments.py
-          - tests/test_fuzzy_search.py
-          - tests/test_integration.py
-          - tests/test_messages.py
-          - tests/test_timestamp_helpers.py
-          - tests/test_versioning.py
-    steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
-        with:
-          version: "0.9.25"
-          enable-cache: true
-      - name: Check file
-        run: uvx --from black==25.1.0 black --check "${{ matrix.path }}"
-
   quality-and-package:
     runs-on: macos-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,10 +44,10 @@ jobs:
         run: uv sync --frozen --extra dev --python 3.13
       - name: Verify version metadata
         run: uv run --frozen --extra dev python scripts/bump_version.py --check --ignore-lock
-      - name: Formatting
-        run: |
-          uv run --frozen --extra dev black --check .
-          uv run --frozen --extra dev isort --check-only .
+      - name: Black formatting
+        run: uv run --frozen --extra dev black --check .
+      - name: Import ordering
+        run: uv run --frozen --extra dev isort --check-only .
       - name: Typing (smoke)
         run: uv run --frozen --extra dev mypy --follow-imports=skip --disable-error-code no-any-return mac_messages_mcp/server.py
       - name: Build distributions

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,34 +2,154 @@ name: Publish Python Package
 
 on:
   push:
+    branches: [main]
     tags:
-      - 'v*'  # Only run when pushing tags that start with 'v'
+      - "v*"
+    paths:
+      - pyproject.toml
+      - manifest.json
+  workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
+
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
-    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-      with:
-        fetch-depth: 0  # Fetch all history for tag discovery
-    
-    - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
-      with:
-        version: "0.9.25"
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0
 
-    - name: Verify tag matches package metadata
-      run: |
-        VERSION=${GITHUB_REF#refs/tags/v}
-        PROJECT_VERSION=$(uv run --no-project python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')
-        MANIFEST_VERSION=$(uv run --no-project python -c 'import json; print(json.load(open("manifest.json"))["version"])')
-        test "$VERSION" = "$PROJECT_VERSION"
-        test "$VERSION" = "$MANIFEST_VERSION"
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          version: "0.9.25"
+          enable-cache: true
 
-    - name: Build and publish
-      run: |
-        uv build
-        uv publish --trusted-publishing always
+      - name: Resolve release version
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="$(uv version --short)"
+          TAG="v${VERSION}"
+          if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Release versions must be stable X.Y.Z values, got ${VERSION}" >&2
+            exit 1
+          fi
+          if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" != "${TAG}" ]]; then
+            echo "Tag ${GITHUB_REF_NAME} does not match package version ${TAG}" >&2
+            exit 1
+          fi
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "tag=${TAG}" >> "${GITHUB_OUTPUT}"
+
+      - name: Synchronize release lockfile
+        if: github.ref_type != 'tag'
+        shell: bash
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          set -euo pipefail
+          uv lock
+          if ! git diff --quiet -- uv.lock; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add uv.lock
+            git commit -m "chore(release): sync uv.lock for ${TAG}"
+            git push origin HEAD:main
+          fi
+
+      - name: Install release dependencies
+        run: uv sync --frozen --extra dev --python 3.13
+
+      - name: Verify version metadata
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: uv run --frozen --extra dev python scripts/bump_version.py --check --expected "${VERSION}"
+
+      - name: Test
+        run: uv run --frozen --extra dev pytest
+
+      - name: Formatting
+        run: |
+          uv run --frozen --extra dev black --check .
+          uv run --frozen --extra dev isort --check-only .
+
+      - name: Typing smoke check
+        run: uv run --frozen --extra dev mypy --follow-imports=skip --disable-error-code no-any-return mac_messages_mcp/server.py
+
+      - name: Build distributions
+        run: uv build
+
+      - name: Verify wheel installation and version
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          uv venv --python 3.13 /tmp/mac-messages-release
+          uv pip install --python /tmp/mac-messages-release/bin/python dist/*.whl
+          INSTALLED_VERSION="$(/tmp/mac-messages-release/bin/python -c 'from importlib.metadata import version; print(version("mac-messages-mcp"))')"
+          test "${INSTALLED_VERSION}" = "${VERSION}"
+
+      - name: Publish to PyPI with trusted publishing
+        run: uv publish --trusted-publishing always --check-url https://pypi.org/simple
+
+      - name: Extract release notes
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          python - <<'PY' > release-notes.md
+          import os
+          import re
+          from pathlib import Path
+
+          version = os.environ["VERSION"]
+          changelog = Path("CHANGELOG.md").read_text(encoding="utf-8")
+          match = re.search(
+              rf"^## \[{re.escape(version)}\].*?\n(?P<body>.*?)(?=^## \[|\Z)",
+              changelog,
+              flags=re.MULTILINE | re.DOTALL,
+          )
+          if match:
+              print(match.group("body").strip())
+          else:
+              print(f"Mac Messages MCP {version}")
+          PY
+
+      - name: Create annotated tag
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          set -euo pipefail
+          git fetch --tags --force
+          RELEASE_SHA="$(git rev-parse HEAD)"
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            TAG_SHA="$(git rev-list -n 1 "${TAG}")"
+            test "${TAG_SHA}" = "${RELEASE_SHA}"
+          else
+            git tag -a "${TAG}" -m "Mac Messages MCP ${TAG}"
+            git push origin "${TAG}"
+          fi
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          set -euo pipefail
+          if gh release view "${TAG}" >/dev/null 2>&1; then
+            gh release edit "${TAG}" \
+              --title "Mac Messages MCP ${TAG}" \
+              --notes-file release-notes.md
+          else
+            gh release create "${TAG}" \
+              --verify-tag \
+              --title "Mac Messages MCP ${TAG}" \
+              --notes-file release-notes.md
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0] - 2026-07-18
+
+### Added
+- Added production macOS CI across Python 3.10, 3.11, 3.12, and 3.13 with formatting, typing, distribution-build, clean-wheel-install, and MCPB architecture checks.
+- Added structured GitHub issue forms and a pull-request template with validation and privacy prompts.
+- Added complete setup guidance for Claude Desktop, Claude Code, Codex, Cursor, VS Code, and other stdio MCP clients.
+- Added focused regression coverage for Messages and AddressBook database access failures.
+
+### Changed
+- Declared the project production-stable and established the first supported `1.x` compatibility contract.
+- Replaced the interactive regex-based version script with an atomic, non-interactive UV-backed workflow that synchronizes `pyproject.toml`, `uv.lock`, and `manifest.json`.
+- Made releases idempotent and reviewable: merged version changes are validated, published to PyPI through OIDC trusted publishing, annotated with a Git tag, and published as a GitHub release.
+- Reworked the README around an install, permissions, client configuration, verification, privacy, and troubleshooting flow.
+
+### Security
+- Hardened local database access with SQLite read-only mode and `query_only` enforcement.
+- Bounded and sanitized message output, escaped AppleScript inputs, and added execution timeouts around Messages automation.
+- Kept attachment discovery metadata-first, with explicit fetches and size limits for inline images.
+- Preserved tokenless PyPI publishing; no long-lived package index credential is stored in GitHub.
+
+### Fixed
+- Normalized direct phone recipients to reliable E.164 values and improved contact result formatting.
+- Improved group-chat filtering, attachment handling, package installation verification, and permission diagnostics.
+
+### Compatibility
+- No intentional breaking Python or MCP tool API changes were introduced from 0.9.2; `1.0.0` marks the stable support boundary.
+
 ## [0.9.2] - 2026-05-10
 
 ### Added

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,68 +1,80 @@
-# Versioning System
+# Versioning and releases
 
-This project uses automatic semantic versioning that follows the [SemVer](https://semver.org/) specification (MAJOR.MINOR.PATCH).
+Mac Messages MCP follows semantic versioning (`MAJOR.MINOR.PATCH`). The package,
+lockfile, Claude Desktop extension manifest, Git tag, PyPI release, and GitHub
+release must all agree on the same version.
 
-## How Versioning Works
+## Bump a version
 
-The versioning system combines manual and automatic processes:
-
-1. **Local Development**: Developers use the `scripts/bump_version.py` script to manually increment version numbers.
-2. **CI/CD Pipeline**: When a version tag is pushed, the GitHub Actions workflow automatically builds and publishes the package with the correct version number.
-
-## Version Bumping
-
-### Using the Bump Script
-
-We provide a convenient script to bump version numbers across all relevant files:
+Use the repository's UV-backed version command:
 
 ```bash
-# To increment the patch version (0.1.0 -> 0.1.1)
-python scripts/bump_version.py patch
-
-# To increment the minor version (0.1.0 -> 0.2.0)
-python scripts/bump_version.py minor
-
-# To increment the major version (0.1.0 -> 1.0.0)
-python scripts/bump_version.py major
+uv run python scripts/bump_version.py major
+uv run python scripts/bump_version.py minor
+uv run python scripts/bump_version.py patch
 ```
 
-The script will:
-1. Update the version in `pyproject.toml`
-2. Update the version in `manifest.json` when the Claude Desktop extension manifest is present
-3. Optionally commit the changes
-4. Optionally create a Git tag
-
-### Publishing a New Version
-
-To publish a new version:
-
-1. Bump the version using the script above
-2. Push the tag to GitHub:
+An explicit stable version is also supported:
 
 ```bash
-git push origin vX.Y.Z
+uv run python scripts/bump_version.py 1.2.3
 ```
 
-This will trigger the GitHub Actions workflow which will:
-1. Verify the tag matches `pyproject.toml` and `manifest.json`
-2. Build the package with uv
-3. Publish it to PyPI using trusted publishing
+The command is deliberately non-interactive. It:
 
-## Version Files
+1. Runs `uv version`, which updates `pyproject.toml` and `uv.lock` together.
+2. Synchronizes the Claude Desktop extension version in `manifest.json`.
+3. Verifies that all three files contain the same stable version.
+4. Rolls every file back if any part of the update fails.
 
-Versions are stored in the following files:
+It does **not** commit, tag, push, or publish. Those are separate reviewable
+operations.
 
-- `pyproject.toml`: The primary source of version information for the package
-- `mac_messages_mcp/__init__.py`: Reads the installed distribution version dynamically
-- `manifest.json`: Contains the Claude Desktop extension package version
-- Git tags: Used to trigger releases and provide version history
+Preview a change without writing files:
 
-## Versioning Guidelines
+```bash
+uv run python scripts/bump_version.py major --dry-run
+```
 
-Follow these guidelines when deciding which version to bump:
+Validate the current repository metadata:
 
-- **PATCH** (0.0.X): Bug fixes and other minor changes
-- **MINOR** (0.X.0): New features or improvements that don't break existing functionality
-- **MAJOR** (X.0.0): Changes that break backward compatibility
+```bash
+uv run python scripts/bump_version.py --check
+```
 
-Always test the package before releasing a new version, especially for MAJOR and MINOR releases.
+## Release process
+
+1. Run the version command.
+2. Add the new release section to `CHANGELOG.md`.
+3. Open and merge a release pull request after CI is green.
+
+A merge to `main` that changes `pyproject.toml` or `manifest.json` starts the
+trusted release workflow. The workflow then:
+
+1. Synchronizes and commits `uv.lock` if the release branch did not include the
+   generated lockfile change.
+2. Re-validates version metadata and runs tests, formatting, typing, build, and
+   clean-wheel installation checks.
+3. Publishes to PyPI using OIDC trusted publishing; no long-lived PyPI token is
+   stored in GitHub.
+4. Creates an annotated `vX.Y.Z` tag only after PyPI succeeds.
+5. Creates or updates the matching GitHub release using the version's changelog
+   section.
+
+Publishing is idempotent: rerunning the workflow skips files already present on
+PyPI and repairs a missing tag or GitHub release.
+
+## Version authority
+
+- `pyproject.toml` is the canonical project version during development.
+- `uv.lock` is synchronized by `uv version`.
+- `manifest.json` mirrors the version for MCPB packaging.
+- `mac_messages_mcp.__version__` reads the installed package metadata at runtime.
+- `vX.Y.Z` tags and GitHub releases are created by the trusted release workflow.
+
+## Choosing a bump
+
+- **PATCH**: backward-compatible fixes.
+- **MINOR**: backward-compatible features and meaningful improvements.
+- **MAJOR**: a compatibility break or a new stability contract, such as the
+  first stable `1.0.0` release.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "mac-messages-mcp",
   "display_name": "Mac Messages MCP",
-  "version": "0.9.2",
+  "version": "1.0.0",
   "description": "Query, search, and send macOS Messages through a local MCP server.",
   "long_description": "Mac Messages MCP runs locally on macOS and provides Claude Desktop with tools for reading recent Messages, fuzzy-searching conversations, resolving contacts, sending iMessage/SMS messages, listing chats, checking permissions, and finding or fetching message attachments. It requires Full Disk Access for Claude Desktop or the terminal used to run it.",
   "author": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mac-messages-mcp"
-version = "0.9.2"
+version = "1.0.0"
 description = "A bridge for interacting with macOS Messages app through MCP"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = "MIT"
@@ -14,7 +14,7 @@ authors = [
 ]
 keywords = ["macos", "messages", "imessage", "mcp"]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
@@ -36,6 +36,8 @@ dependencies = [
 "Homepage" = "https://github.com/carterlasalle/mac_messages_mcp"
 "Bug Tracker" = "https://github.com/carterlasalle/mac_messages_mcp/issues"
 "Source" = "https://github.com/carterlasalle/mac_messages_mcp"
+"Changelog" = "https://github.com/carterlasalle/mac_messages_mcp/blob/main/CHANGELOG.md"
+"Releases" = "https://github.com/carterlasalle/mac_messages_mcp/releases"
 
 [project.optional-dependencies]
 dev = [

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,150 +1,234 @@
 #!/usr/bin/env python3
-"""
-Bump version script for mac-messages-mcp package.
+"""Synchronize project release versions using uv.
 
 Usage:
-    python scripts/bump_version.py [major|minor|patch]
-    python scripts/bump_version.py --help
+    uv run python scripts/bump_version.py major
+    uv run python scripts/bump_version.py minor
+    uv run python scripts/bump_version.py patch
+    uv run python scripts/bump_version.py 1.2.3
+    uv run python scripts/bump_version.py --check [--expected 1.2.3]
 
-Default is patch if no argument is provided.]
+The script intentionally does not commit, tag, or push. It delegates the canonical
+project and lockfile update to ``uv version``, then synchronizes ``manifest.json``.
 """
 
+from __future__ import annotations
+
+import argparse
 import json
-import os
 import re
+import shutil
 import subprocess
 import sys
+import tempfile
+import tomllib
 from pathlib import Path
+from typing import Iterable
 
-# Define version pattern
-VERSION_PATTERN = r"\d+\.\d+\.\d+"
-
-
-def print_help():
-    """Print help information"""
-    print(__doc__)
-    sys.exit(0)
+PROJECT_NAME = "mac-messages-mcp"
+BUMP_KINDS = {"major", "minor", "patch"}
+STABLE_VERSION_RE = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
+VERSION_FILES = ("pyproject.toml", "uv.lock", "manifest.json")
 
 
-def get_current_version():
-    """Read the current version from pyproject.toml"""
-    pyproject_path = Path("pyproject.toml")
-    if not pyproject_path.exists():
-        print("Error: pyproject.toml not found!")
-        sys.exit(1)
-
-    content = pyproject_path.read_text()
-    version_match = re.search(r'version = "(' + VERSION_PATTERN + ')"', content)
-    if not version_match:
-        print("Error: Could not find version in pyproject.toml!")
-        sys.exit(1)
-
-    return version_match.group(1)
+class VersionError(RuntimeError):
+    """Raised when version metadata is missing or inconsistent."""
 
 
-def bump_version(current_version, bump_type):
-    """Bump the version according to the specified type"""
-    major, minor, patch = map(int, current_version.split("."))
+def _load_toml(path: Path) -> dict:
+    try:
+        with path.open("rb") as handle:
+            return tomllib.load(handle)
+    except FileNotFoundError as exc:
+        raise VersionError(f"Required file not found: {path}") from exc
+    except tomllib.TOMLDecodeError as exc:
+        raise VersionError(f"Invalid TOML in {path}: {exc}") from exc
 
-    if bump_type == "major":
-        major += 1
-        minor = 0
-        patch = 0
-    elif bump_type == "minor":
-        minor += 1
-        patch = 0
-    elif bump_type == "patch":
-        patch += 1
+
+def read_versions(root: Path) -> dict[str, str]:
+    """Read the version from all release metadata files."""
+    pyproject = _load_toml(root / "pyproject.toml")
+    project = pyproject.get("project", {})
+    project_version = project.get("version")
+    if project.get("name") != PROJECT_NAME or not isinstance(project_version, str):
+        raise VersionError(
+            "pyproject.toml is missing the expected project name/version"
+        )
+
+    manifest_path = root / "manifest.json"
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise VersionError(f"Required file not found: {manifest_path}") from exc
+    except json.JSONDecodeError as exc:
+        raise VersionError(f"Invalid JSON in {manifest_path}: {exc}") from exc
+    manifest_version = manifest.get("version")
+    if not isinstance(manifest_version, str):
+        raise VersionError("manifest.json is missing a string version")
+
+    lock = _load_toml(root / "uv.lock")
+    lock_version = None
+    for package in lock.get("package", []):
+        if package.get("name") == PROJECT_NAME:
+            lock_version = package.get("version")
+            break
+    if not isinstance(lock_version, str):
+        raise VersionError(f"uv.lock has no package entry for {PROJECT_NAME}")
+
+    return {
+        "pyproject.toml": project_version,
+        "uv.lock": lock_version,
+        "manifest.json": manifest_version,
+    }
+
+
+def validate_versions(
+    root: Path, *, expected: str | None = None, ignore_lock: bool = False
+) -> str:
+    """Return the synchronized version or raise VersionError."""
+    versions = read_versions(root)
+    compared = {
+        name: version
+        for name, version in versions.items()
+        if not (ignore_lock and name == "uv.lock")
+    }
+    unique = set(compared.values())
+    if len(unique) != 1:
+        details = ", ".join(f"{name}={version}" for name, version in compared.items())
+        raise VersionError(f"Version metadata is inconsistent: {details}")
+
+    version = next(iter(unique))
+    if expected is not None and version != expected:
+        raise VersionError(f"Expected version {expected}, found {version}")
+    return version
+
+
+def _atomic_write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    rendered = json.dumps(payload, indent=2) + "\n"
+    with tempfile.NamedTemporaryFile(
+        mode="w", encoding="utf-8", dir=path.parent, delete=False
+    ) as handle:
+        handle.write(rendered)
+        temporary = Path(handle.name)
+    temporary.replace(path)
+
+
+def sync_manifest(root: Path, version: str) -> None:
+    path = root / "manifest.json"
+    try:
+        manifest = json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError) as exc:
+        raise VersionError(f"Cannot update {path}: {exc}") from exc
+    manifest["version"] = version
+    _atomic_write_json(path, manifest)
+
+
+def _snapshot(root: Path, names: Iterable[str]) -> dict[Path, bytes | None]:
+    snapshot: dict[Path, bytes | None] = {}
+    for name in names:
+        path = root / name
+        snapshot[path] = path.read_bytes() if path.exists() else None
+    return snapshot
+
+
+def _restore(snapshot: dict[Path, bytes | None]) -> None:
+    for path, content in snapshot.items():
+        if content is None:
+            path.unlink(missing_ok=True)
+        else:
+            path.write_bytes(content)
+
+
+def set_version(root: Path, target: str, *, dry_run: bool = False) -> str:
+    """Use uv to update pyproject.toml/uv.lock, then sync manifest.json."""
+    if shutil.which("uv") is None:
+        raise VersionError("uv is required but was not found on PATH")
+
+    if target in BUMP_KINDS:
+        version_args = ["--bump", target]
+    elif STABLE_VERSION_RE.fullmatch(target):
+        version_args = [target]
     else:
-        print(f"Error: Invalid bump type '{bump_type}'!")
-        print("Usage: python scripts/bump_version.py [major|minor|patch]")
-        sys.exit(1)
+        raise VersionError(
+            "Version target must be major, minor, patch, or a stable X.Y.Z version"
+        )
 
-    return f"{major}.{minor}.{patch}"
+    command = ["uv", "version", *version_args, "--no-sync"]
+    if dry_run:
+        command.append("--dry-run")
+        subprocess.run(command, cwd=root, check=True)
+        return validate_versions(root, ignore_lock=False)
+
+    snapshot = _snapshot(root, VERSION_FILES)
+    try:
+        subprocess.run(command, cwd=root, check=True)
+        pyproject_version = read_versions(root)["pyproject.toml"]
+        sync_manifest(root, pyproject_version)
+        return validate_versions(root, expected=pyproject_version)
+    except (OSError, subprocess.CalledProcessError, VersionError):
+        _restore(snapshot)
+        raise
 
 
-def update_files(new_version):
-    """Update version in all relevant files"""
-    # Update pyproject.toml
-    pyproject_path = Path("pyproject.toml")
-    content = pyproject_path.read_text()
-    updated_content = re.sub(
-        r'version = "' + VERSION_PATTERN + '"', f'version = "{new_version}"', content
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "target",
+        nargs="?",
+        help="major, minor, patch, or an explicit stable X.Y.Z version",
     )
-    pyproject_path.write_text(updated_content)
-
-    # Update Claude Desktop extension manifest when present
-    manifest_path = Path("manifest.json")
-    if manifest_path.exists():
-        manifest = json.loads(manifest_path.read_text())
-        manifest["version"] = new_version
-        manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
-
-    print(f"Updated version to {new_version} in pyproject.toml and manifest.json")
-
-
-def create_git_tag(new_version):
-    """Create a new git tag and push it"""
-    tag_name = f"v{new_version}"
-
-    # Create tag
-    subprocess.run(["git", "tag", tag_name], check=True)
-    print(f"Created git tag: {tag_name}")
-
-    # Inform how to push the tag
-    print("\nTo push the tag to GitHub and trigger a release, run:")
-    print(f"  git push origin {tag_name}")
+    parser.add_argument(
+        "--check", action="store_true", help="validate metadata without changing files"
+    )
+    parser.add_argument("--expected", help="require this exact version with --check")
+    parser.add_argument(
+        "--ignore-lock",
+        action="store_true",
+        help="ignore uv.lock during --check (intended only for pre-release CI)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="show uv's proposed change without writing",
+    )
+    parser.add_argument("--root", type=Path, default=Path.cwd(), help=argparse.SUPPRESS)
+    return parser
 
 
-def main():
-    # Check for help request
-    if len(sys.argv) > 1 and sys.argv[1] in ["-h", "--help", "help"]:
-        print_help()
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    root = args.root.resolve()
+    try:
+        if args.check:
+            if args.target or args.dry_run:
+                raise VersionError(
+                    "--check cannot be combined with a version target or --dry-run"
+                )
+            version = validate_versions(
+                root, expected=args.expected, ignore_lock=args.ignore_lock
+            )
+            print(version)
+            return 0
 
-    # Determine bump type
-    bump_type = "patch"  # Default
-    if len(sys.argv) > 1:
-        bump_type = sys.argv[1].lower()
-        if bump_type not in ["major", "minor", "patch"]:
-            print(f"Invalid bump type: {bump_type}")
-            print("Usage: python scripts/bump_version.py [major|minor|patch]")
-            sys.exit(1)
+        if args.expected or args.ignore_lock:
+            raise VersionError("--expected and --ignore-lock require --check")
+        if not args.target:
+            raise VersionError("Provide major, minor, patch, X.Y.Z, or --check")
 
-    # Get current version
-    current_version = get_current_version()
-    print(f"Current version: {current_version}")
-
-    # Bump version
-    new_version = bump_version(current_version, bump_type)
-    print(f"New version: {new_version}")
-
-    # Update files
-    update_files(new_version)
-
-    # Ask to commit changes
-    commit_changes = input("Do you want to commit these changes? [y/N]: ").lower()
-    if commit_changes == "y":
-        subprocess.run(
-            [
-                "git",
-                "add",
-                "pyproject.toml",
-                "manifest.json",
-            ],
-            check=True,
+        version = set_version(root, args.target, dry_run=args.dry_run)
+        if not args.dry_run:
+            print(f"Version synchronized at {version} ({', '.join(VERSION_FILES)})")
+        return 0
+    except VersionError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+    except subprocess.CalledProcessError as exc:
+        print(
+            f"Error: uv version failed with exit code {exc.returncode}", file=sys.stderr
         )
-        subprocess.run(
-            ["git", "commit", "-m", f"Bump version to {new_version}"], check=True
-        )
-        print("Changes committed.")
-
-        # Create git tag
-        create_tag = input(
-            f"Do you want to create git tag v{new_version}? [y/N]: "
-        ).lower()
-        if create_tag == "y":
-            create_git_tag(new_version)
+        return exc.returncode or 1
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -21,7 +21,6 @@ import shutil
 import subprocess
 import sys
 import tempfile
-import tomllib
 from pathlib import Path
 from typing import Iterable
 
@@ -35,25 +34,98 @@ class VersionError(RuntimeError):
     """Raised when version metadata is missing or inconsistent."""
 
 
-def _load_toml(path: Path) -> dict:
+def _read_string_assignment(line: str) -> tuple[str, str] | None:
+    """Parse a simple quoted TOML assignment used by release metadata."""
+    key, separator, raw_value = line.partition("=")
+    if not separator:
+        return None
+    key = key.strip()
+    raw_value = raw_value.strip()
     try:
-        with path.open("rb") as handle:
-            return tomllib.load(handle)
+        value = json.loads(raw_value)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(value, str):
+        return None
+    return key, value
+
+
+def _read_project_metadata(path: Path) -> tuple[str, str]:
+    """Read project name/version without adding a Python 3.10 TOML dependency."""
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
     except FileNotFoundError as exc:
         raise VersionError(f"Required file not found: {path}") from exc
-    except tomllib.TOMLDecodeError as exc:
-        raise VersionError(f"Invalid TOML in {path}: {exc}") from exc
+
+    in_project = False
+    project_name = None
+    project_version = None
+    for raw_line in lines:
+        line = raw_line.strip()
+        if line.startswith("[") and line.endswith("]"):
+            in_project = line == "[project]"
+            continue
+        if not in_project or not line or line.startswith("#"):
+            continue
+        assignment = _read_string_assignment(line)
+        if assignment is None:
+            continue
+        key, value = assignment
+        if key == "name":
+            project_name = value
+        elif key == "version":
+            project_version = value
+
+    if project_name != PROJECT_NAME or project_version is None:
+        raise VersionError(
+            "pyproject.toml is missing the expected project name/version"
+        )
+    return project_name, project_version
+
+
+def _read_lock_version(path: Path) -> str:
+    """Read this project's package version from uv.lock."""
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except FileNotFoundError as exc:
+        raise VersionError(f"Required file not found: {path}") from exc
+
+    package_name = None
+    package_version = None
+    in_package = False
+    for raw_line in lines:
+        line = raw_line.strip()
+        if line == "[[package]]":
+            if package_name == PROJECT_NAME and package_version is not None:
+                return package_version
+            package_name = None
+            package_version = None
+            in_package = True
+            continue
+        if line.startswith("[["):
+            if package_name == PROJECT_NAME and package_version is not None:
+                return package_version
+            in_package = False
+            continue
+        if not in_package or not line or line.startswith("#"):
+            continue
+        assignment = _read_string_assignment(line)
+        if assignment is None:
+            continue
+        key, value = assignment
+        if key == "name":
+            package_name = value
+        elif key == "version":
+            package_version = value
+
+    if package_name == PROJECT_NAME and package_version is not None:
+        return package_version
+    raise VersionError(f"uv.lock has no package entry for {PROJECT_NAME}")
 
 
 def read_versions(root: Path) -> dict[str, str]:
     """Read the version from all release metadata files."""
-    pyproject = _load_toml(root / "pyproject.toml")
-    project = pyproject.get("project", {})
-    project_version = project.get("version")
-    if project.get("name") != PROJECT_NAME or not isinstance(project_version, str):
-        raise VersionError(
-            "pyproject.toml is missing the expected project name/version"
-        )
+    _, project_version = _read_project_metadata(root / "pyproject.toml")
 
     manifest_path = root / "manifest.json"
     try:
@@ -66,14 +138,7 @@ def read_versions(root: Path) -> dict[str, str]:
     if not isinstance(manifest_version, str):
         raise VersionError("manifest.json is missing a string version")
 
-    lock = _load_toml(root / "uv.lock")
-    lock_version = None
-    for package in lock.get("package", []):
-        if package.get("name") == PROJECT_NAME:
-            lock_version = package.get("version")
-            break
-    if not isinstance(lock_version, str):
-        raise VersionError(f"uv.lock has no package entry for {PROJECT_NAME}")
+    lock_version = _read_lock_version(root / "uv.lock")
 
     return {
         "pyproject.toml": project_version,

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -1,0 +1,104 @@
+import importlib.util
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "bump_version.py"
+SPEC = importlib.util.spec_from_file_location("release_version", SCRIPT_PATH)
+assert SPEC and SPEC.loader
+bump_version = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(bump_version)
+
+
+def write_project(root: Path, version: str = "0.9.2") -> None:
+    (root / "pyproject.toml").write_text(
+        '[project]\nname = "mac-messages-mcp"\n'
+        f'version = "{version}"\nrequires-python = ">=3.10"\n',
+        encoding="utf-8",
+    )
+    (root / "manifest.json").write_text(
+        json.dumps({"name": "mac-messages-mcp", "version": version}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    (root / "uv.lock").write_text(
+        'version = 1\nrevision = 3\nrequires-python = ">=3.10"\n\n'
+        '[[package]]\nname = "mac-messages-mcp"\n'
+        f'version = "{version}"\nsource = {{ virtual = "." }}\n',
+        encoding="utf-8",
+    )
+
+
+def test_validate_versions_accepts_synchronized_metadata(tmp_path: Path) -> None:
+    write_project(tmp_path)
+    assert bump_version.validate_versions(tmp_path, expected="0.9.2") == "0.9.2"
+
+
+def test_validate_versions_reports_mismatch(tmp_path: Path) -> None:
+    write_project(tmp_path)
+    manifest = json.loads((tmp_path / "manifest.json").read_text())
+    manifest["version"] = "1.0.0"
+    (tmp_path / "manifest.json").write_text(json.dumps(manifest))
+
+    with pytest.raises(bump_version.VersionError, match="inconsistent"):
+        bump_version.validate_versions(tmp_path)
+
+
+def test_set_version_delegates_to_uv_and_syncs_manifest(tmp_path: Path) -> None:
+    write_project(tmp_path)
+
+    def fake_uv(command, *, cwd, check):
+        assert command == ["uv", "version", "--bump", "major", "--no-sync"]
+        assert cwd == tmp_path
+        assert check is True
+        write_project(tmp_path, "1.0.0")
+        # Simulate uv updating only pyproject + lock; the script owns manifest sync.
+        manifest = {"name": "mac-messages-mcp", "version": "0.9.2"}
+        (tmp_path / "manifest.json").write_text(json.dumps(manifest))
+        return subprocess.CompletedProcess(command, 0)
+
+    with patch.object(
+        bump_version.shutil, "which", return_value="/usr/bin/uv"
+    ), patch.object(bump_version.subprocess, "run", side_effect=fake_uv):
+        assert bump_version.set_version(tmp_path, "major") == "1.0.0"
+
+    assert json.loads((tmp_path / "manifest.json").read_text())["version"] == "1.0.0"
+    assert bump_version.validate_versions(tmp_path) == "1.0.0"
+
+
+def test_set_version_rolls_back_all_files_on_failure(tmp_path: Path) -> None:
+    write_project(tmp_path)
+    before = {
+        name: (tmp_path / name).read_bytes() for name in bump_version.VERSION_FILES
+    }
+
+    def failing_uv(command, *, cwd, check):
+        (tmp_path / "pyproject.toml").write_text("broken")
+        raise subprocess.CalledProcessError(1, command)
+
+    with patch.object(
+        bump_version.shutil, "which", return_value="/usr/bin/uv"
+    ), patch.object(
+        bump_version.subprocess, "run", side_effect=failing_uv
+    ), pytest.raises(
+        subprocess.CalledProcessError
+    ):
+        bump_version.set_version(tmp_path, "major")
+
+    assert {
+        name: (tmp_path / name).read_bytes() for name in bump_version.VERSION_FILES
+    } == before
+
+
+def test_main_requires_explicit_action(tmp_path: Path, capsys) -> None:
+    write_project(tmp_path)
+    assert bump_version.main(["--root", str(tmp_path)]) == 2
+    assert "Provide major, minor, patch" in capsys.readouterr().err
+
+
+def test_explicit_version_must_be_stable_semver(tmp_path: Path) -> None:
+    write_project(tmp_path)
+    with pytest.raises(bump_version.VersionError, match="stable X.Y.Z"):
+        bump_version.set_version(tmp_path, "1.0.0rc1")

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -59,9 +59,10 @@ def test_set_version_delegates_to_uv_and_syncs_manifest(tmp_path: Path) -> None:
         (tmp_path / "manifest.json").write_text(json.dumps(manifest))
         return subprocess.CompletedProcess(command, 0)
 
-    with patch.object(
-        bump_version.shutil, "which", return_value="/usr/bin/uv"
-    ), patch.object(bump_version.subprocess, "run", side_effect=fake_uv):
+    with (
+        patch.object(bump_version.shutil, "which", return_value="/usr/bin/uv"),
+        patch.object(bump_version.subprocess, "run", side_effect=fake_uv),
+    ):
         assert bump_version.set_version(tmp_path, "major") == "1.0.0"
 
     assert json.loads((tmp_path / "manifest.json").read_text())["version"] == "1.0.0"
@@ -78,12 +79,10 @@ def test_set_version_rolls_back_all_files_on_failure(tmp_path: Path) -> None:
         (tmp_path / "pyproject.toml").write_text("broken")
         raise subprocess.CalledProcessError(1, command)
 
-    with patch.object(
-        bump_version.shutil, "which", return_value="/usr/bin/uv"
-    ), patch.object(
-        bump_version.subprocess, "run", side_effect=failing_uv
-    ), pytest.raises(
-        subprocess.CalledProcessError
+    with (
+        patch.object(bump_version.shutil, "which", return_value="/usr/bin/uv"),
+        patch.object(bump_version.subprocess, "run", side_effect=failing_uv),
+        pytest.raises(subprocess.CalledProcessError),
     ):
         bump_version.set_version(tmp_path, "major")
 


### PR DESCRIPTION
## Summary

Cut the first stable Mac Messages MCP release and replace the old interactive versioning flow with a deterministic UV-backed release process.

### Versioning

- Rewrites `scripts/bump_version.py` as a non-interactive command.
- Delegates package and lockfile updates to `uv version`.
- Synchronizes `manifest.json` atomically.
- Validates `pyproject.toml`, `uv.lock`, and `manifest.json`.
- Rolls back every version file if any step fails.
- Supports the repository's full Python 3.10–3.13 range without adding a runtime TOML dependency.
- Removes commit/tag/push prompts from the script.
- Adds focused versioning and rollback tests.

### Releases

- Publishes to PyPI with OIDC trusted publishing and duplicate-file checks.
- Synchronizes `uv.lock` before a release and commits the generated lock change when necessary.
- Runs tests, Black, isort, typing, build, and clean-wheel validation before publishing.
- Creates an annotated `vX.Y.Z` tag only after PyPI succeeds.
- Creates or repairs the matching GitHub release from the changelog.
- Keeps manual tag and workflow-dispatch recovery paths.

### 1.0.0

- Bumps package and MCPB metadata from `0.9.2` to `1.0.0`.
- Promotes the PyPI classifier to Production/Stable.
- Adds the complete 1.0.0 changelog and release notes.

## Validation

- [x] Python 3.10, 3.11, 3.12, and 3.13 test matrix.
- [x] Version metadata validation.
- [x] Black and isort.
- [x] Mypy smoke check.
- [x] Distribution build and clean-wheel installation.
- [x] MCPB arm64 build.
- [x] MCPB x86_64 build.

## Release behavior after merge

The merge changes `pyproject.toml` and `manifest.json`, which triggers the trusted publish workflow. That workflow synchronizes `uv.lock`, publishes `1.0.0` to PyPI, creates annotated tag `v1.0.0`, and creates the GitHub release only after validation and publication succeed.