### PR TITLE
Fix Semgrep workflow to run an OSS scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "0.9.25"
@@ -37,7 +37,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "0.9.25"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
       tag: ${{ steps.version.outputs.tag }}
       release_sha: ${{ steps.release_sha.outputs.sha }}
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -115,7 +115,7 @@ jobs:
       contents: write
       id-token: write
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.prepare.outputs.release_sha }}
           fetch-depth: 0

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,49 +1,39 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
-# This workflow file requires a free account on Semgrep.dev to
-# manage rules, file ignores, notifications, and more.
-#
-# See https://semgrep.dev/docs
-
 name: Semgrep
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [main]
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ "main" ]
+    branches: [main]
   schedule:
-    - cron: '23 19 * * 2'
+    - cron: "23 19 * * 2"
+  workflow_dispatch:
 
 permissions:
   contents: read
 
+concurrency:
+  group: semgrep-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   semgrep:
-    permissions:
-      contents: read # for actions/checkout to fetch code
-      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
-      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     name: Scan
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
+    permissions:
+      contents: read
+      security-events: write
+    container:
+      image: semgrep/semgrep
     steps:
-      # Checkout project source
-      - uses: actions/checkout@v4
-
-      # Scan code using project's configuration on https://semgrep.dev/manage
-      - uses: returntocorp/semgrep-action@fcd5ab7459e8d91cb1777481980d1b18b4fc6735
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          publishToken: ${{ secrets.SEMGREP_APP_TOKEN }}
-          publishDeployment: ${{ secrets.SEMGREP_DEPLOYMENT_ID }}
-          generateSarif: "1"
-
-      # Upload SARIF file generated in previous step
-      - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3
+          persist-credentials: false
+      - name: Run Semgrep
+        run: semgrep scan --config p/default --config p/python --sarif --output=semgrep.sarif --metrics=off
+      - name: Upload SARIF
+        if: success()
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: semgrep.sarif
-        if: always()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replace the GitHub Semgrep starter on `main` with an OSS `semgrep scan` workflow that does not need a Semgrep Cloud account.

The starter used unmaintained `returntocorp/semgrep-action`, required `SEMGREP_APP_TOKEN` / `SEMGREP_DEPLOYMENT_ID` (unset here, so scans no-op or fail), left `actions/checkout@v4` and `github/codeql-action/upload-sarif@v3` unpinned, and uploaded SARIF with `if: always()`.

This PR:

- Runs `semgrep scan --config p/default --config p/python` in `semgrep/semgrep` (not `semgrep ci`)
- Pins `actions/checkout` to `3d3c42e…` (`v7.0.1`, same SHA as post-#68 main) with `persist-credentials: false`
- Pins `github/codeql-action/upload-sarif` to `cdf488f…` (`v4.37.9`, same pin as `codeql.yml` on main)
- Uploads SARIF only on `success()`
- Skips `dependabot[bot]` so lock bumps do not burn minutes
- Fixes leftover `# v5` comments on that checkout SHA in `ci.yml` / `publish.yml`

`--error` is omitted on purpose: a local `semgrep scan` of current main reported 4 findings (Dependabot cooldown, Dockerfile `USER`, and a trusted `urllib` fetch in `scripts/build_mcpb.py`). SARIF still uploads so GitHub code scanning can surface them without failing the job.

Does not touch `untrusted.py` / the #67 security boundary. Does not bump `mcp` or `starlette`.

## Validation

- [x] Local `semgrep scan --config p/default --config p/python --metrics=off` (4 existing findings; `--error` dropped so CI stays green)
- [ ] `uv sync --frozen --extra dev` (workflow-only change)
- [ ] `uv run --frozen --extra dev pytest` (workflow-only change)
- [ ] `uv run --frozen --extra dev black --check .`
- [ ] `uv run --frozen --extra dev isort --check-only .`
- [ ] `uv build`

## Privacy / permissions checklist

- [x] No private Messages or Contacts data is committed
- [x] Any new tool output is scoped to requested fields only
- [x] Permission changes (if any) are documented in README/SECURITY notes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d601a1c-bb7a-4d97-92f3-9cdf6fd16f52?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d601a1c-bb7a-4d97-92f3-9cdf6fd16f52&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

