### PR TITLE
Release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-09-01
+
 ### Security
-- Messages/Contacts-derived MCP tool and resource output is structurally neutralized and returned in an explicit `<untrusted-mcp-output>` block. Embedded newlines cannot form extra transcript lines; invisible, format, and bidi characters are shown as escapes. This is not an anti-injection guarantee. Fence idempotence is an in-process marker, so attacker text that only *looks* fenced is still re-serialized.
-- CodeQL workflow pins actions to commit SHAs and analyzes Python with `security-extended` queries. Dependabot is configured for the `uv` and `github-actions` ecosystems.
+- MCP tool and resource output derived from Messages and Contacts is serialized at a single untrusted-output boundary (`present_untrusted_output`). Newlines become the literal two-character sequence `\n`; invisible, bidi, and format Unicode is escaped; fence terminators inside content are defanged; and the payload is wrapped in `<untrusted-mcp-output>` so it is not treated as instructions. Fence idempotence uses an in-process marker, so attacker text that only looks already-fenced is still re-serialized. This is not an anti-injection guarantee.
+- Clients must still gate `tool_send_message`. The locked `mcp` 1.3.0 FastMCP API has no elicitation, and a `confirm=True` argument is not human confirmation.
+- Coordinated reports from Grégoire Compagnon (obeone) prompted this output-boundary work.
+- CodeQL actions are pinned to commit SHAs and analyze Python with `security-extended` queries. Dependabot covers the `uv` and `github-actions` ecosystems. A Semgrep OSS scan (`semgrep scan` in the official `semgrep/semgrep` image) replaced the unused GitHub-starter Semgrep workflow that required `SEMGREP_APP_TOKEN`.
+
+### Added
+- Added `MAC_MESSAGES_REGION` to override the region used when parsing national-format numbers, for Macs configured for a different region than their phone numbers belong to.
+- Added `phonenumbers` as a dependency, replacing the hand-rolled country-code heuristics.
 
 ### Fixed
 - Phone numbers written in national format are now expanded to E.164 against the region the Mac is configured for instead of being assumed North American. A French number such as `06 39 98 00 01` was previously turned into `+10639980001`, which made contact listings show the wrong country code and made message lookups, attachment lookups and iMessage availability checks miss handles that exist in the database.
@@ -20,10 +28,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Email handles are compared case-insensitively on both sides, so an address stored in mixed case is found whichever way it is typed.
 - Email addresses are looked up as handles instead of being sent to fuzzy contact-name matching, which answered "No contacts found" for any address that is not in the address book and returned before the handle query could run.
 - Recipients are refused for being dialable only from inside their own local area rather than for having fewer than ten digits. The digit floor rejected every numbering plan shorter than the North American one, an eight-digit Norwegian number among them, while still letting through the seven-digit North American local form it was meant to catch. Several numbering plans consider a short national form possible, a seven-digit North American local among them, so a half-typed number was being expanded and handed to Messages.app.
+- Credit: Grégoire Compagnon (obeone) for the region-aware phone and email handle work ([#64](https://github.com/carterlasalle/mac_messages_mcp/pull/64)).
 
-### Added
-- Added `MAC_MESSAGES_REGION` to override the region national-format numbers are parsed against, for Macs configured for a different region than their phone numbers belong to.
-- Added `phonenumbers` as a dependency, replacing the hand-rolled country-code heuristics.
+### Changed
+- Upgraded Pillow from 12.2.0 to 12.3.0.
+- Updated indirect dependencies: python-dotenv 1.2.2, idna 3.15, and pygments 2.20.0.
+- GitHub Actions: `actions/checkout` v7.0.1 (SHA-pinned), `astral-sh/setup-uv` v10, and `pypa/gh-action-pypi-publish` 1.14.2.
+- CI jobs now set `timeout-minutes` so a stuck macOS runner acquire fails closed.
 
 ## [1.0.0] - 2026-07-18
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "mac-messages-mcp",
   "display_name": "Mac Messages MCP",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Query, search, and send macOS Messages through a local MCP server.",
   "long_description": "Mac Messages MCP 1.0 runs locally on macOS and provides Claude Desktop with stable tools for reading recent Messages, fuzzy-searching conversations, resolving contacts, sending iMessage/SMS messages, listing chats, checking permissions, and finding or fetching message attachments. It requires Full Disk Access for Claude Desktop or the terminal used to run it.",
   "author": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mac-messages-mcp"
-version = "1.0.0"
+version = "1.1.0"
 description = "A bridge for interacting with macOS Messages app through MCP"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -267,7 +267,7 @@ wheels = [
 
 [[package]]
 name = "mac-messages-mcp"
-version = "1.0.0"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Ship **1.1.0** so the trusted publish workflow can tag and publish the work that landed on `main` after the July 1.0.0 contract.

`pyproject.toml` and `manifest.json` have said `1.0.0` since July, but PyPI and git tags still stop at `0.9.2` / `v0.9.2`. No `v1.0.0` tag or PyPI 1.0.0 artifact exists. This PR bumps metadata to **1.1.0** and records the post-1.0.0 security boundary, region-aware phone/email handle work, and dependency/CI updates so a merge to `main` can publish and tag that combined set.

This is a minor release: backward-compatible features and meaningful security/phone improvements. It does not bump `mcp` or `starlette`, and it does not change `untrusted.py`.

Do **not** git tag or `gh release create` by hand. Tagging is the publish job's job after PyPI succeeds.

### What 1.1.0 contains vs 1.0.0

- **Security:** one untrusted-output boundary (`present_untrusted_output`) for Messages/Contacts MCP tool and resource output; clients must still gate `tool_send_message`. CodeQL SHA pins, Dependabot (`uv`, `github-actions`), Semgrep OSS scan.
- **Added:** `MAC_MESSAGES_REGION`, `phonenumbers` instead of country-code heuristics.
- **Fixed:** region-aware E.164 / email handle matching (obeone, #64).
- **Changed:** Pillow 12.3.0, indirect dotenv/idna/pygments, GitHub Actions pins, CI `timeout-minutes`.

Full notes are in `CHANGELOG.md` under `## [1.1.0] - 2026-09-01`.

## Validation

- [x] `uv run python scripts/bump_version.py 1.1.0`
- [x] `uv run python scripts/bump_version.py --check --expected 1.1.0`
- [x] `uv run --frozen --extra dev pytest` (225 passed locally)
- [x] `uv run --frozen --extra dev black --check .`
- [x] `uv run --frozen --extra dev isort --check-only .`
- [ ] `uv build` (CI `quality-and-package` is the merge gate)

CI on this PR is the merge gate. If it is green, squash-merge so publish runs on `main`. If only the known empty 3.12 runner-acquire flake remains and the other Python versions passed, merge anyway.

## Privacy / permissions checklist

- [x] No private Messages or Contacts data is committed
- [x] Any new tool output is scoped to requested fields only
- [x] Permission changes (if any) are documented in README/SECURITY notes
- [x] Changelog does not include injection payloads, group-name forgeries, or private report details

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e16165fd-a0da-478b-a66a-ac6fb42a48f4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e16165fd-a0da-478b-a66a-ac6fb42a48f4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

