### PR TITLE
Fix PyPI verify to skip non-distribution files in dist/

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -175,9 +175,17 @@ jobs:
               item["filename"]: item["digests"]["sha256"]
               for item in payload.get("urls", [])
           }
-          local_files = sorted(Path("dist").iterdir())
-          if not local_files:
-              raise SystemExit("No local distributions were built")
+          local_files = sorted(
+              path
+              for path in Path("dist").iterdir()
+              if path.is_file() and path.name.endswith((".whl", ".tar.gz"))
+          )
+          wheels = [path for path in local_files if path.name.endswith(".whl")]
+          sdists = [path for path in local_files if path.name.endswith(".tar.gz")]
+          if not wheels:
+              raise SystemExit("No local wheel was built")
+          if not sdists:
+              raise SystemExit("No local sdist was built")
           for path in local_files:
               digest = hashlib.sha256(path.read_bytes()).hexdigest()
               if path.name not in remote:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The 1.1.0 publish job uploaded the wheel and sdist, then failed at **Verify PyPI filenames and SHA-256 digests** because `Path("dist").iterdir()` treated every file as a distribution. `uv build` / the workspace left a `.gitignore` in `dist/`, so the job exited with `PyPI is missing .gitignore`. There is still no `v1.1.0` tag or GitHub Release.

This change is **`publish.yml` only**:

- Compare only local files whose names end with `.whl` or `.tar.gz`.
- Require at least one wheel and one sdist.
- Keep SHA-256 matching against PyPI JSON.

The changelog named group is already `(?P<body>.*?)`; it is unchanged.

Does not bump version. Does not change `untrusted.py`, `mcp`, or `starlette`. After merge, re-run the failed Publish Python Package workflow on `main` (`skip-existing: true`) so it can create annotated tag `v1.1.0` and the GitHub Release.

## Validation

- [x] Inspected `.github/workflows/publish.yml` verify step
- [ ] `uv sync --frozen --extra dev` (workflow-only change)
- [ ] `uv run --frozen --extra dev pytest` (workflow-only change)
- [ ] `uv run --frozen --extra dev black --check .`
- [ ] `uv run --frozen --extra dev isort --check-only .`
- [ ] `uv build`

CI on this PR is the merge gate. If it is green, squash-merge. If only the known empty 3.12 runner-acquire flake remains and the other Python versions passed, merge anyway.

## Privacy / permissions checklist

- [x] No private Messages or Contacts data is committed
- [x] Any new tool output is scoped to requested fields only
- [x] Permission changes (if any) are documented in README/SECURITY notes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c7f1cea1-35ee-4f41-939b-252fadb014a5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c7f1cea1-35ee-4f41-939b-252fadb014a5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

