### PR TITLE
Trigger trusted publish for v1.1.0 without a version bump

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mac-messages-mcp"
+# Canonical version. Changing this file or manifest.json triggers trusted publish.
 version = "1.1.0"
 description = "A bridge for interacting with macOS Messages app through MCP"
 readme = {file = "README.md", content-type = "text/markdown"}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`gh workflow run "Publish Python Package" --ref main` returns **403** for this agent (`Resource not accessible by integration`). Changing `publish.yml` also does not start the workflow.

PyPI already has **1.1.0**. `main` now includes:

- #77 verify skip of non-distribution files
- #78 skip-existing digest handling

This PR does **not** bump the version. It adds a comment in `pyproject.toml` so the documented path filter starts trusted publish on merge. `skip-existing: true` will leave PyPI 1.1.0 in place; the remaining steps should create annotated tag `v1.1.0` and the GitHub Release.

## Validation

- [x] `scripts/bump_version.py` still reads `1.1.0`
- [ ] `uv sync --frozen --extra dev`
- [ ] `uv run --frozen --extra dev pytest`
- [ ] `uv run --frozen --extra dev black --check .`
- [ ] `uv run --frozen --extra dev isort --check-only .`
- [ ] `uv build`

## Privacy / permissions checklist

- [x] No private Messages or Contacts data is committed
- [x] Any new tool output is scoped to requested fields only
- [x] Permission changes (if any) are documented in README/SECURITY notes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c7f1cea1-35ee-4f41-939b-252fadb014a5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c7f1cea1-35ee-4f41-939b-252fadb014a5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

