### PR TITLE
fix: make security workflows produce real SARIF/SBOM results

### DIFF
--- a/.github/workflows/anchore-syft.yml
+++ b/.github/workflows/anchore-syft.yml
@@ -3,10 +3,10 @@
 # separate terms of service, privacy policy, and support
 # documentation.
 
-# This workflow checks out code, builds an image, performs a container image
-# scan with Anchore's Syft tool, and uploads the results to the GitHub Dependency
-# submission API.
-
+# Build the local image, generate SBOMs for both the Python source tree
+# (uv.lock) and the image, upload workflow artifacts, and submit a
+# dependency snapshot to the GitHub Dependency Graph.
+#
 # For more information on the Anchore sbom-action usage
 # and parameters, see https://github.com/anchore/sbom-action. For more
 # information about the Anchore SBOM tool, Syft, see
@@ -15,7 +15,10 @@ name: Anchore Syft SBOM scan
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -26,13 +29,22 @@ jobs:
       contents: write # required to upload to the Dependency submission API
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout the code
-      uses: actions/checkout@v4
-    - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag localbuild/testimage:latest
-    - name: Scan the image and upload dependency results
-      uses: anchore/sbom-action@bb716408e75840bbb01e839347cd213767269d4a
-      with:
-        image: "localbuild/testimage:latest"
-        artifact-name: image.spdx.json
-        dependency-snapshot: true
+      - name: Checkout the code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Build the Docker image
+        run: docker build . --file Dockerfile --tag localbuild/testimage:latest
+
+      - name: Scan source directory and upload dependency results
+        uses: anchore/sbom-action@3ad7283483fc7af8ff2b4ea19663c2d5ca935e26 # v0.24.2
+        with:
+          path: .
+          artifact-name: sbom-source
+          dependency-snapshot: true
+
+      - name: Scan the image and upload dependency results
+        uses: anchore/sbom-action@3ad7283483fc7af8ff2b4ea19663c2d5ca935e26 # v0.24.2
+        with:
+          image: localbuild/testimage:latest
+          artifact-name: sbom-image
+          dependency-snapshot: true

--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -4,49 +4,46 @@
 # documentation.
 
 # Bandit is a security linter designed to find common security issues in Python code.
-# This action will run Bandit on your codebase.
-# The results of the scan will be found under the Security tab of your repository.
-
-# https://github.com/marketplace/actions/bandit-scan is ISC licensed, by abirismyname
+# Results are uploaded as SARIF to the repository Security tab.
+#
 # https://pypi.org/project/bandit/ is Apache v2.0 licensed, by PyCQA
 
 name: Bandit
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ "main" ]
+    branches: ["main"]
   schedule:
-    - cron: '38 22 * * 6'
+    - cron: "38 22 * * 6"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
 
 jobs:
   bandit:
     permissions:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
-      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
-
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Bandit Scan
-        uses: shundor/python-bandit-scan@ab1d87dfccc5a0ffab88be3aaac6ffe35c10d6cd
-        with: # optional arguments
-          # exit with 0, even with results found
-          exit_zero: true # optional, default is DEFAULT
-          # Github token of the repository (automatically created by Github)
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information.
-          # File or directory to run bandit on
-          # path: # optional, default is .
-          # Report only issues of a given severity level or higher. Can be LOW, MEDIUM or HIGH. Default is UNDEFINED (everything)
-          # level: # optional, default is UNDEFINED
-          # Report only issues of a given confidence level or higher. Can be LOW, MEDIUM or HIGH. Default is UNDEFINED (everything)
-          # confidence: # optional, default is UNDEFINED
-          # comma-separated list of paths (glob patterns supported) to exclude from scan (note that these are in addition to the excluded paths provided in the config file) (default: .svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg)
-          # excluded_paths: # optional, default is DEFAULT
-          # comma-separated list of test IDs to skip
-          # skips: # optional, default is DEFAULT
-          # path to a .bandit file that supplies command line arguments
-          # ini_path: # optional, default is DEFAULT
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.9.25"
+
+      - name: Run Bandit
+        run: >
+          uvx --from 'bandit[sarif]' bandit
+          -r mac_messages_mcp tests
+          -f sarif
+          -o bandit.sarif
+          --exit-zero
+
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          sarif_file: bandit.sarif

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -7,10 +7,10 @@
 #
 # Source repository: https://github.com/actions/dependency-review-action
 # Public documentation: https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review#dependency-review-enforcement
-name: 'Dependency review'
+name: "Dependency review"
 on:
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 # If using a dependency submission action in this workflow this permission will need to be set to:
 #
@@ -27,10 +27,10 @@ jobs:
   dependency-review:
     runs-on: ubuntu-latest
     steps:
-      - name: 'Checkout repository'
-        uses: actions/checkout@v4
-      - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v4
+      - name: "Checkout repository"
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: "Dependency Review"
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         # Commonly enabled options, see https://github.com/actions/dependency-review-action#configuration-options for all available options.
         with:
           comment-summary-in-pr: always

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -3,8 +3,8 @@
 # separate terms of service, privacy policy, and support
 # documentation.
 
-# A sample workflow which sets up periodic OSV-Scanner scanning for vulnerabilities,
-# in addition to a PR check which fails if new vulnerabilities are introduced.
+# Periodic OSV-Scanner scanning for vulnerabilities, plus a PR check
+# that fails if new vulnerabilities are introduced.
 #
 # For more examples and options, including how to ignore specific vulnerabilities,
 # see https://google.github.io/osv-scanner/github-action/
@@ -13,15 +13,18 @@ name: OSV-Scanner
 
 on:
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
   merge_group:
-    branches: [ "main" ]
+    branches: ["main"]
   schedule:
-    - cron: '24 14 * * 1'
+    - cron: "24 14 * * 1"
   push:
-    branches: [ "main" ]
+    branches: ["main"]
+  workflow_dispatch:
 
 permissions:
+  # Required to upload SARIF file to CodeQL. See: https://github.com/github/codeql-action/issues/2117
+  actions: read
   # Require writing security events to upload SARIF file to security tab
   security-events: write
   # Read commit contents
@@ -29,20 +32,29 @@ permissions:
 
 jobs:
   scan-scheduled:
-    if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@1f1242919d8a60496dd1874b24b62b2370ed4c78" # v1.7.1
+    if: ${{ github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    permissions:
+      actions: read
+      security-events: write
+      contents: read
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@6e4298ebc4db23e847df9b2e2de2939d6f066c67 # v2.5.1
     with:
-      # Example of specifying custom arguments
+      # Recursive source scan finds uv.lock / pyproject.toml. v2 dropped --skip-git
+      # (skipping the root git dir is now the default).
       scan-args: |-
         -r
-        --skip-git
         ./
+      # Upload SARIF even when known vulns exist; fail only if the scanner/reporter errors.
+      fail-on-vuln: false
+
   scan-pr:
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@1f1242919d8a60496dd1874b24b62b2370ed4c78" # v1.7.1
+    permissions:
+      actions: read
+      security-events: write
+      contents: read
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@6e4298ebc4db23e847df9b2e2de2939d6f066c67 # v2.5.1
     with:
-      # Example of specifying custom arguments
       scan-args: |-
         -r
-        --skip-git
         ./

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -10,9 +10,12 @@ on:
   # To guarantee Maintained check is occasionally updated. See
   # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
   schedule:
-    - cron: '35 13 * * 5'
+    - cron: "35 13 * * 5"
   push:
-    branches: [ "main" ]
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
 
 # Declare default permissions as read only.
 permissions: read-all
@@ -22,7 +25,7 @@ jobs:
     name: Scorecard analysis
     runs-on: ubuntu-latest
     # `publish_results: true` only works when run from the default branch. conditional can be removed if disabled.
-    if: github.event.repository.default_branch == github.ref_name || github.event_name == 'pull_request'
+    if: github.event.repository.default_branch == github.ref_name || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write
@@ -34,12 +37,12 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75731b0186 # v2.4.1
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif
@@ -73,6 +76,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -13,8 +13,6 @@ on:
     - cron: "35 13 * * 5"
   push:
     branches: ["main"]
-  pull_request:
-    branches: ["main"]
   workflow_dispatch:
 
 # Declare default permissions as read only.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Carter's security workflows were GitHub starter templates that did not actually produce usable results. This PR pins third-party actions by commit SHA and wires each workflow to a real output path.

- **Syft** — artifact name `image.spdx.json` is invalid on the current Actions artifact API (dots), so the job died after a successful Docker build. Scan now covers source (`path: .`, including `uv.lock`) and the local image; artifacts are `sbom-source` and `sbom-image`; `dependency-snapshot` stays on. `anchore/sbom-action` is pinned to v0.24.2 at the peeled commit SHA (not the annotated tag object). Verified on this PR: both artifacts uploaded and both dependency snapshots submitted.
- **Bandit** — `shundor/python-bandit-scan` with `exit_zero: true` was a fake-green marketplace path. Replaced with `uvx --from 'bandit[sarif]'` writing `bandit.sarif`, then `github/codeql-action/upload-sarif` (v4.37.9). `--exit-zero` keeps findings from blocking the upload. Verified: SARIF uploaded to code scanning.
- **OSV** — reusable workflows were pinned to ancient v1.7.1. Updated to v2.5.1. Dropped `--skip-git` (removed in v2; root git skip is now default). Recursive `-r ./` still finds `uv.lock` / `pyproject.toml`. Scheduled/push uploads SARIF without failing the job on existing vulns; the PR job still fails on **new** vulns vs base. Permissions include `actions: read` as the reusable workflow requires for SARIF upload. Verified: scanned `uv.lock` (46 packages) and uploaded SARIF.
- **Scorecard** — `upload-sarif` was floating `@v3` and checkout was v4.2.2. Pinned checkout v7.0.1, upload-sarif v4.37.9, scorecard-action v2.4.4. Still `publish_results: true` with `id-token: write`; no SCORECARD_TOKEN. Kept off `pull_request` (plus `workflow_dispatch`) so GitHub Advanced Security does not fail PRs over default-branch-only Scorecard checks.
- **dependency-review** — `on: pull_request` only is correct (it diffs PR manifests vs base), but checkout and the action were unpinned. Pinned checkout v7.0.1 and `actions/dependency-review-action` v5.0.0. Still `comment-summary-in-pr: always`. Verified: summary comment posted on this PR.

`workflow_dispatch` added to Syft, Bandit, OSV, and Scorecard. `ci.yml`, `codeql.yml`, `semgrep.yml`, and `publish.yml` are untouched.

## Validation

Workflow-only change. Success is the checks on this PR (and Syft artifact names / SARIF uploads), not a local pytest run.

- [x] `publish.yml` not modified
- [x] Third-party actions pinned by full commit SHA with version comments
- [x] First PR run: Syft artifacts + snapshots, Bandit SARIF, OSV SARIF, dependency-review comment
- [ ] Re-run green after removing Scorecard `pull_request` trigger
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f2ee61a-6cb3-40c8-a92d-958da45d7380?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f2ee61a-6cb3-40c8-a92d-958da45d7380&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

