### PR TITLE
Set git identity so publish can create annotated tag v1.1.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -229,6 +229,8 @@ jobs:
           TAG: ${{ needs.prepare.outputs.tag }}
         run: |
           set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git fetch --tags --force
           if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
             TAG_SHA="$(git rev-list -n 1 "${TAG}")"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mac-messages-mcp"
-# Canonical version. Changing this file or manifest.json triggers trusted publish.
+# Canonical version. A change to this file or manifest.json starts trusted publish.
 version = "1.1.0"
 description = "A bridge for interacting with macOS Messages app through MCP"
 readme = {file = "README.md", content-type = "text/markdown"}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Publish run [33546482992](https://github.com/carterlasalle/mac_messages_mcp/actions/runs/33546482992) got through PyPI verify (`skip-existing` for 1.1.0) and then failed at **Create annotated tag**:

```
fatal: empty ident name ... not allowed
```

The publish job never set `user.name` / `user.email` for `git tag -a`. This PR sets the same github-actions[bot] identity used by the lockfile sync step.

`pyproject.toml` is touched **without a version bump** so merge starts trusted publish on a SHA that includes this identity fix. Remaining steps should create `v1.1.0` and the GitHub Release.

## Validation

- [x] Inspected failed tag step on run 33546482992
- [ ] `uv sync --frozen --extra dev`
- [ ] `uv run --frozen --extra dev pytest`
- [ ] `uv run --frozen --extra dev black --check .`
- [ ] `uv run --frozen --extra dev isort --check-only .`
- [ ] `uv build`

## Privacy / permissions checklist

- [x] No private Messages or Contacts data is committed
- [x] Any new tool output is scoped to requested fields only
- [x] Permission changes (if any) are documented in README/SECURITY notes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c7f1cea1-35ee-4f41-939b-252fadb014a5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c7f1cea1-35ee-4f41-939b-252fadb014a5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

