### PR TITLE
Clear remaining Scorecard, CodeQL, and Semgrep alerts

### DIFF
--- a/.github/workflows/anchore-syft.yml
+++ b/.github/workflows/anchore-syft.yml
@@ -21,7 +21,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   Anchore-Build-Scan:

--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -20,7 +20,6 @@ on:
 
 permissions:
   contents: read
-  security-events: write
 
 jobs:
   bandit:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: "34 20 * * 4"
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -20,11 +20,12 @@ on:
 # https://docs.github.com/en/enterprise-cloud@latest/code-security/supply-chain-security/understanding-your-software-supply-chain/using-the-dependency-submission-api
 permissions:
   contents: read
-  # Write permissions for pull-requests are required for using the `comment-summary-in-pr` option, comment out if you aren't using this option
-  pull-requests: write
 
 jobs:
   dependency-review:
+    permissions:
+      contents: read
+      pull-requests: write # comment-summary-in-pr
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout repository"

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -34,4 +34,4 @@ jobs:
           set -euo pipefail
           uv venv --python 3.13
           uv pip install atheris phonenumbers
-          uv run python fuzz/fuzz_phone.py -runs=2048
+          .venv/bin/python fuzz/fuzz_phone.py -runs=2048

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,37 @@
+name: Fuzz
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "41 5 * * 3"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: fuzz-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fuzz-phone:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.9.25"
+
+      - name: Fuzz phone parsers
+        run: |
+          set -euo pipefail
+          uv venv --python 3.13
+          uv pip install atheris phonenumbers
+          uv run python fuzz/fuzz_phone.py -runs=2048

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -23,11 +23,6 @@ on:
   workflow_dispatch:
 
 permissions:
-  # Required to upload SARIF file to CodeQL. See: https://github.com/github/codeql-action/issues/2117
-  actions: read
-  # Require writing security events to upload SARIF file to security tab
-  security-events: write
-  # Read commit contents
   contents: read
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 35
     permissions:
-      contents: write
+      contents: write # git commit/push of a synchronized uv.lock on untagged releases
     outputs:
       version: ${{ steps.version.outputs.version }}
       tag: ${{ steps.version.outputs.tag }}
@@ -112,8 +112,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     permissions:
-      contents: write
-      id-token: write
+      contents: write # annotated tag + GitHub release after PyPI succeeds
+      id-token: write # PyPI trusted publishing
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- GitHub Actions workflows now declare read-only `GITHUB_TOKEN` permissions at the workflow level and grant write scopes only on the jobs that upload SARIF, submit SBOMs, comment on PRs, or publish releases.
+- Contact/message text cleaning no longer uses a regex character class spanning U+24C2–U+1F251, which CodeQL flagged as an overly permissive range and which also stripped CJK.
+- The MCPB builder fetches `uv` over HTTPS with an allowlisted redirect host set instead of `urllib.request.urlopen`.
+- Added a bounded Atheris harness for phone/handle parsers (`fuzz/fuzz_phone.py`).
+
 ## [1.1.0] - 2026-09-01
 
 ### Security

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,10 +1,21 @@
 # Security Policy
 
+## Supported versions
+
 Security fixes are applied to the latest release and the `main` branch.
 
-Report vulnerabilities privately through GitHub's **Security → Report a vulnerability** flow for this repository (private vulnerability reporting is enabled). Include affected versions, reproduction steps, impact, and any suggested remediation. Do not include real message contents, contact records, phone numbers, or attachment files.
+| Version | Supported |
+| ------- | --------- |
+| 1.1.x   | Yes       |
+| < 1.1   | Best-effort on `main` only |
 
-The project aims to acknowledge a report within 72 hours and provide an initial severity assessment within seven days.
+## Reporting a vulnerability
+
+Report vulnerabilities privately through GitHub's **Security → Report a vulnerability** flow for this repository (private vulnerability reporting is enabled). That is the coordinated-disclosure channel; do not open a public issue for an unfixed vulnerability.
+
+Include affected versions, reproduction steps, impact, and any suggested remediation. Do not include real message contents, contact records, phone numbers, or attachment files.
+
+The project aims to acknowledge a report within 72 hours and provide an initial severity assessment within seven days. See the [OpenSSF coordinated vulnerability disclosure guide](https://github.com/ossf/oss-vulnerability-guide/blob/main/guide.md) for the process this project follows.
 
 ## Local trust boundary
 
@@ -15,3 +26,11 @@ This server runs with the permissions of the application that launches it. Full 
 Tool and resource payloads derived from Messages or Contacts are structurally neutralized and returned inside `<untrusted-mcp-output>`. That labeling is not an anti-injection guarantee. Third-party iMessage/SMS/RCS content can still attempt prompt injection; the server makes that content non-structural and explicit so a client can refuse to treat it as authorization, confirmation, or tool instructions. Prompt injection cannot be fully solved inside this server.
 
 `tool_send_message` is a privileged side-effect. This server does not implement client-mediated human approval (the locked `mcp` 1.3.0 FastMCP API has no elicitation/`ctx.elicit` support, and a `confirm=True` argument would be agent-settable). MCP clients must gate sends themselves.
+
+## Scorecard checks that cannot be set from this tree
+
+These OpenSSF Scorecard rows are GitHub organization/repository settings or an external badge. Files in this repository cannot enable them, and CI must not fake the badge or protection:
+
+- **Branch-Protection**: a maintainer must enable a `main` ruleset or classic branch protection that blocks force-pushes and deletions, requires a pull request, requires at least one approving review, dismisses stale reviews, and requires status checks. Scorecard's public run also cannot *see* some of those flags without a `SCORECARD_TOKEN` PAT that has Administration:read; the PAT only observes settings, it does not turn protection on.
+- **Code-Review**: follows from requiring reviews on `main`. Merging with admin bypass, or committing directly to `main`, keeps this check at zero even when workflows are correct.
+- **CII-Best-Practices**: register the project at [OpenSSF Best Practices](https://www.bestpractices.dev/) and complete the passing badge. A workflow cannot mint that badge.

--- a/fuzz/fuzz_phone.py
+++ b/fuzz/fuzz_phone.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Short Atheris fuzz of phone/handle parsers.
+
+Scorecard's Fuzzing check looks for ``import atheris`` in Python sources.
+This harness is also run in CI for a bounded number of iterations.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import atheris
+
+ROOT = Path(__file__).resolve().parents[1]
+PHONE_PATH = ROOT / "mac_messages_mcp" / "phone.py"
+
+
+def _load_phone():
+    spec = importlib.util.spec_from_file_location("mac_messages_mcp_phone", PHONE_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {PHONE_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+phone = _load_phone()
+
+
+@atheris.instrument_func
+def TestOneInput(data: bytes) -> None:
+    fdp = atheris.FuzzedDataProvider(data)
+    text = fdp.ConsumeUnicodeNoSurrogates(512)
+    phone.canonical_handle(text)
+    phone.to_e164(text)
+    phone.to_dialable_e164(text)
+    phone.handle_variants(text)
+    phone.is_email_handle(text)
+
+
+def main() -> None:
+    atheris.instrument_all()
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/mac_messages_mcp/messages.py
+++ b/mac_messages_mcp/messages.py
@@ -251,21 +251,34 @@ _CONTACTS_CACHE = None
 _LAST_CACHE_UPDATE = 0
 _CACHE_TTL = 300  # 5 minutes in seconds
 
-_EMOJI_PATTERN = re.compile(
-    "["
-    "\U0001f600-\U0001f64f"  # emoticons
-    "\U0001f300-\U0001f5ff"  # symbols & pictographs
-    "\U0001f680-\U0001f6ff"  # transport & map symbols
-    "\U0001f700-\U0001f77f"  # alchemical symbols
-    "\U0001f780-\U0001f7ff"  # Geometric Shapes
-    "\U0001f800-\U0001f8ff"  # Supplemental Arrows-C
-    "\U0001f900-\U0001f9ff"  # Supplemental Symbols and Pictographs
-    "\U0001fa00-\U0001fa6f"  # Chess Symbols
-    "\U0001fa70-\U0001faff"  # Symbols and Pictographs Extended-A
-    "\U00002702-\U000027b0"  # Dingbats
-    "\U000024c2-\U0001f251"
-    "]+"
+# Inclusive (start, end) code-point ranges for characters stripped as emoji.
+# Kept as ordinal comparisons so CodeQL py/overly-large-range does not treat
+# supplementary-plane regex ranges as overlapping U+FFFD, and so the old
+# catch-all U+24C2–U+1F251 span cannot swallow CJK and other non-emoji text.
+_EMOJI_ORDINAL_RANGES = (
+    (0x1F600, 0x1F64F),  # emoticons
+    (0x1F300, 0x1F5FF),  # symbols & pictographs
+    (0x1F680, 0x1F6FF),  # transport & map symbols
+    (0x1F700, 0x1F77F),  # alchemical symbols
+    (0x1F780, 0x1F7FF),  # geometric shapes extended
+    (0x1F800, 0x1F8FF),  # supplemental arrows-C
+    (0x1F900, 0x1F9FF),  # supplemental symbols and pictographs
+    (0x1FA00, 0x1FA6F),  # chess symbols
+    (0x1FA70, 0x1FAFF),  # symbols and pictographs extended-A
+    (0x2702, 0x27B0),  # dingbats
+    (0x2600, 0x26FF),  # miscellaneous symbols (☀, ⚡, ♥, …)
+    (0x24C2, 0x24C2),  # circled M
+    (0x1F170, 0x1F251),  # enclosed alphanumeric supplement through 🉑
 )
+
+
+def _is_emoji_codepoint(codepoint: int) -> bool:
+    return any(start <= codepoint <= end for start, end in _EMOJI_ORDINAL_RANGES)
+
+
+def _strip_emoji(text: str) -> str:
+    return "".join(ch for ch in text if not _is_emoji_codepoint(ord(ch)))
+
 
 _MAX_MESSAGE_BODY_CHARS = 4_000
 
@@ -279,7 +292,7 @@ def _clean_text(text: str, strip_punctuation: bool = False) -> str:
             alphanumeric, whitespace, apostrophes, or hyphens (used for
             contact-name matching).
     """
-    text = _EMOJI_PATTERN.sub("", text)
+    text = _strip_emoji(text)
     if strip_punctuation:
         text = re.sub(r"[^\w\s\'\-]", "", text, flags=re.UNICODE)
     text = re.sub(r"\s+", " ", text).strip()

--- a/scripts/build_mcpb.py
+++ b/scripts/build_mcpb.py
@@ -20,6 +20,7 @@ downloads Python and dependencies, so network access is required once.
 """
 
 import hashlib
+import http.client
 import json
 import platform
 import shutil
@@ -27,13 +28,23 @@ import subprocess
 import sys
 import tarfile
 import tempfile
-import urllib.request
 from pathlib import Path
+from urllib.parse import urljoin, urlparse
 
 # Pinned uv release for reproducible builds; override with --uv-version.
 DEFAULT_UV_VERSION = "0.11.19"
 UV_DOWNLOAD_PREFIX = "https://github.com/astral-sh/uv/releases/download/"
 UV_DOWNLOAD_URL = UV_DOWNLOAD_PREFIX + "{version}/{asset}.tar.gz"
+_ALLOWED_DOWNLOAD_HOSTS = frozenset(
+    {
+        "github.com",
+        "objects.githubusercontent.com",
+        "github-releases.githubusercontent.com",
+        "release-assets.githubusercontent.com",
+    }
+)
+_DOWNLOAD_TIMEOUT_SECONDS = 60
+_MAX_DOWNLOAD_REDIRECTS = 8
 
 # Map architecture aliases to uv's macOS release asset names.
 ARCH_ASSETS = {
@@ -70,11 +81,48 @@ def _download(url):
     if not url.startswith(UV_DOWNLOAD_PREFIX):
         raise ValueError(f"refusing to download untrusted URL: {url}")
     print(f"Downloading {url}")
-    request = urllib.request.Request(url, method="GET")
-    # fmt: off
-    with urllib.request.urlopen(request) as response:  # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
-        return response.read()
-    # fmt: on
+    return _https_get_allowlisted(url)
+
+
+def _https_get_allowlisted(url):
+    """GET `url` over HTTPS, following redirects only to known GitHub hosts."""
+    current = url
+    for _ in range(_MAX_DOWNLOAD_REDIRECTS):
+        parsed = urlparse(current)
+        if (
+            parsed.scheme != "https"
+            or not parsed.hostname
+            or parsed.hostname not in _ALLOWED_DOWNLOAD_HOSTS
+        ):
+            raise ValueError(f"refusing to download untrusted URL: {current}")
+        path = parsed.path or "/"
+        if parsed.query:
+            path = f"{path}?{parsed.query}"
+        connection = http.client.HTTPSConnection(
+            parsed.hostname, timeout=_DOWNLOAD_TIMEOUT_SECONDS
+        )
+        try:
+            connection.request(
+                "GET",
+                path,
+                headers={"User-Agent": "mac-messages-mcp-mcpb-builder"},
+            )
+            response = connection.getresponse()
+            if response.status in (301, 302, 303, 307, 308):
+                location = response.getheader("Location")
+                response.read()
+                if not location:
+                    raise ValueError(f"redirect without Location from {current}")
+                current = urljoin(current, location)
+                continue
+            if response.status != 200:
+                raise ValueError(
+                    f"download failed: HTTP {response.status} for {current}"
+                )
+            return response.read()
+        finally:
+            connection.close()
+    raise ValueError(f"too many redirects downloading {url}")
 
 
 def vendor_uv(asset, version):

--- a/tests/test_build_mcpb.py
+++ b/tests/test_build_mcpb.py
@@ -1,6 +1,6 @@
 import importlib.util
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -9,6 +9,16 @@ SPEC = importlib.util.spec_from_file_location("build_mcpb", SCRIPT_PATH)
 assert SPEC and SPEC.loader
 build_mcpb = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(build_mcpb)
+
+
+def _https_response(status, body=b"", location=None):
+    response = MagicMock()
+    response.status = status
+    response.read.return_value = body
+    response.getheader.side_effect = lambda name: (
+        location if name == "Location" else None
+    )
+    return response
 
 
 def test_download_rejects_non_release_url():
@@ -21,9 +31,53 @@ def test_download_allows_pinned_uv_release_url():
         version=build_mcpb.DEFAULT_UV_VERSION,
         asset="uv-aarch64-apple-darwin",
     )
-    with patch.object(build_mcpb.urllib.request, "urlopen") as mock_open:
-        mock_open.return_value.__enter__.return_value.read.return_value = b"uv"
+    connection = MagicMock()
+    connection.getresponse.return_value = _https_response(200, b"uv")
+    with patch.object(
+        build_mcpb.http.client, "HTTPSConnection", return_value=connection
+    ) as mock_conn:
         assert build_mcpb._download(url) == b"uv"
-        mock_open.assert_called_once()
-        request = mock_open.call_args[0][0]
-        assert request.full_url.startswith(build_mcpb.UV_DOWNLOAD_PREFIX)
+        mock_conn.assert_called_once()
+        assert mock_conn.call_args[0][0] == "github.com"
+        connection.request.assert_called_once()
+        method, path = connection.request.call_args[0][:2]
+        assert method == "GET"
+        assert path.startswith("/astral-sh/uv/releases/download/")
+
+
+def test_download_follows_allowlisted_redirect():
+    url = build_mcpb.UV_DOWNLOAD_URL.format(
+        version=build_mcpb.DEFAULT_UV_VERSION,
+        asset="uv-aarch64-apple-darwin",
+    )
+    github = MagicMock()
+    github.getresponse.return_value = _https_response(
+        302,
+        location="https://objects.githubusercontent.com/uv.tar.gz",
+    )
+    objects = MagicMock()
+    objects.getresponse.return_value = _https_response(200, b"uv-bytes")
+
+    def _connect(host, timeout=None):
+        return github if host == "github.com" else objects
+
+    with patch.object(build_mcpb.http.client, "HTTPSConnection", side_effect=_connect):
+        assert build_mcpb._download(url) == b"uv-bytes"
+    objects.request.assert_called_once()
+    assert objects.request.call_args[0][1] == "/uv.tar.gz"
+
+
+def test_download_refuses_redirect_off_github():
+    url = build_mcpb.UV_DOWNLOAD_URL.format(
+        version=build_mcpb.DEFAULT_UV_VERSION,
+        asset="uv-aarch64-apple-darwin",
+    )
+    connection = MagicMock()
+    connection.getresponse.return_value = _https_response(
+        302, location="https://evil.example/payload"
+    )
+    with patch.object(
+        build_mcpb.http.client, "HTTPSConnection", return_value=connection
+    ):
+        with pytest.raises(ValueError, match="untrusted URL"):
+            build_mcpb._download(url)

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -11,12 +11,14 @@ from unittest.mock import MagicMock, patch
 
 from mac_messages_mcp.messages import (
     _check_imessage_availability,
+    _clean_text,
     _connect_sqlite_readonly,
     _find_chat_by_identifier,
     _format_phone_for_messages,
     _sanitize_message_body,
     _send_message_to_recipient,
     _verify_send_in_db,
+    clean_name,
     escape_applescript,
     extract_body_from_attributed,
     find_contact_by_name,
@@ -177,6 +179,20 @@ class TestEscapeAppleScriptInjection(unittest.TestCase):
 
         # Check results
         self.assertEqual(result, "Hello 世界")
+
+
+class TestCleanText(unittest.TestCase):
+    """Emoji stripping must not use an overly large regex range."""
+
+    def test_strips_emoticons_and_dingbats(self):
+        self.assertEqual(_clean_text("Hugo 😀 Example ✂"), "Hugo Example")
+
+    def test_preserves_cjk_and_latin_letters(self):
+        self.assertEqual(_clean_text("田中 太郎"), "田中 太郎")
+        self.assertEqual(_clean_text("José"), "José")
+
+    def test_clean_name_strips_punctuation_after_emoji(self):
+        self.assertEqual(clean_name("Alice 🎉!"), "Alice")
 
 
 class TestSanitizeMessageBody(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Least-privilege workflow tokens; CodeQL regex no longer overly broad; Semgrep urllib replaced with allowlisted HTTPS.
- SECURITY.md, Atheris fuzz job (runs via `.venv/bin/python` so atheris is not pruned), Scorecard SAST/fuzz/policy coverage.
- Closes leftover Dependabot path: PR #83 already closed as superseded by #84.

Written blockers (GitHub settings, not this PR): branch protection (208), required reviews (218), CII Best Practices badge (220).

Factory GS-002. Adversarial review: empty findings after fuzz.yml auto-fix, risk low. Do not merge without captain word via Firstmate.

## Test plan
- [x] pytest 234 passed on the writer
- [x] Atheris import + short fuzz run via `.venv/bin/python`
- [ ] CI on this PR